### PR TITLE
Defusedxml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ __pycache__/
 /build
 /dist
 /htmlcov
+
+tox_conda_tmp*.yaml


### PR DESCRIPTION
**Notes**

- It's utilizing xml library but only for the Element object which `defusedxml` does not support. The `xml` vulnerabilities comes from `.parse()`, `.toString()`, and `.fromString()` which is now coming from `defusedxml`. More info about this: https://pypi.org/project/defusedxml/ and  [github issue 48](https://github.com/tiran/defusedxml/issues/48) / [github issue 43](https://github.com/tiran/defusedxml/issues/43). 

**Test**

- Ran tox command. Failed at Py39 and Py311. But all the unit test passed under Py310
