### PR TITLE
feat: add HAE and DEM projections to SICD sensor model

### DIFF
--- a/src/aws/osml/formats/sicd/__init__.py
+++ b/src/aws/osml/formats/sicd/__init__.py
@@ -1,1 +1,0 @@
-# nothing here

--- a/src/aws/osml/gdal/gdal_dem_tile_factory.py
+++ b/src/aws/osml/gdal/gdal_dem_tile_factory.py
@@ -1,9 +1,16 @@
 import logging
 from typing import Any, Optional, Tuple
 
+import numpy as np
 from osgeo import gdal
 
-from aws.osml.photogrammetry import DigitalElevationModelTileFactory, GDALAffineSensorModel
+from aws.osml.photogrammetry import (
+    DigitalElevationModelTileFactory,
+    ElevationRegionSummary,
+    GDALAffineSensorModel,
+    ImageCoordinate,
+    geodetic_to_geocentric,
+)
 
 
 class GDALDigitalElevationModelTileFactory(DigitalElevationModelTileFactory):
@@ -24,7 +31,9 @@ class GDALDigitalElevationModelTileFactory(DigitalElevationModelTileFactory):
         super().__init__()
         self.tile_directory = tile_directory
 
-    def get_tile(self, tile_path: str) -> Tuple[Optional[Any], Optional[GDALAffineSensorModel]]:
+    def get_tile(
+        self, tile_path: str
+    ) -> Tuple[Optional[Any], Optional[GDALAffineSensorModel], Optional[ElevationRegionSummary]]:
         """
         Retrieve a numpy array of elevation values and a sensor model.
 
@@ -32,7 +41,7 @@ class GDALDigitalElevationModelTileFactory(DigitalElevationModelTileFactory):
 
         :param tile_path: the location of the tile to load
 
-        :return: an array of elevation values and a sensor model or (None, None)
+        :return: an array of elevation values, a sensor model, and a summary or (None, None, None)
         """
         tile_location = f"{self.tile_directory}/{tile_path}"
         tile_location = tile_location.replace("s3:/", "/vsis3", 1)
@@ -43,15 +52,31 @@ class GDALDigitalElevationModelTileFactory(DigitalElevationModelTileFactory):
         # information isn't available.
         if not ds:
             logging.debug(f"No DEM tile available for {tile_path}. Checked {tile_location}")
-            return None, None
+            return None, None, None
 
         # If the raster exists but doesn't have a geo transform then it is likely invalid input data.
         geo_transform = ds.GetGeoTransform(can_return_null=True)
         if not geo_transform:
             logging.warning(f"DEM tile does not have geo transform metadata and can't be used: {tile_location}")
-            return None, None
+            return None, None, None
 
-        band_as_array = ds.GetRasterBand(1).ReadAsArray(0, 0, ds.RasterXSize, ds.RasterYSize)
+        raster_band = ds.GetRasterBand(1)
+        band_as_array = raster_band.ReadAsArray(0, 0, ds.RasterXSize, ds.RasterYSize)
+        height, width = band_as_array.shape
         sensor_model = GDALAffineSensorModel(geo_transform)
 
-        return band_as_array, sensor_model
+        # Compute the distance in meters from the upper left to the lower right corner. Divide that by the distance
+        # in pixels to get an approximate pixel size in meters
+        ul_corner_ecf = geodetic_to_geocentric(sensor_model.image_to_world(ImageCoordinate([0, 0]))).coordinate
+        lr_corner_ecf = geodetic_to_geocentric(sensor_model.image_to_world(ImageCoordinate([width, height]))).coordinate
+        post_spacing = np.linalg.norm(ul_corner_ecf - lr_corner_ecf) / np.sqrt(width * width + height * height)
+
+        stats = raster_band.GetStatistics(True, True)
+        summary = ElevationRegionSummary(
+            min_elevation=stats[0],
+            max_elevation=stats[1],
+            no_data_value=raster_band.GetNoDataValue(),
+            post_spacing=post_spacing,
+        )
+
+        return band_as_array, sensor_model, summary

--- a/src/aws/osml/photogrammetry/__init__.py
+++ b/src/aws/osml/photogrammetry/__init__.py
@@ -16,7 +16,7 @@ from .coordinates import (
     geodetic_to_geocentric,
 )
 from .digital_elevation_model import DigitalElevationModel, DigitalElevationModelTileFactory, DigitalElevationModelTileSet
-from .elevation_model import ConstantElevationModel, ElevationModel
+from .elevation_model import ConstantElevationModel, ElevationModel, ElevationRegionSummary
 from .gdal_sensor_model import GDALAffineSensorModel
 from .projective_sensor_model import ProjectiveSensorModel
 from .replacement_sensor_model import (
@@ -57,6 +57,7 @@ __all__ = [
     "DigitalElevationModelTileSet",
     "ConstantElevationModel",
     "ElevationModel",
+    "ElevationRegionSummary",
     "GDALAffineSensorModel",
     "SARImageCoordConverter",
     "INCAProjectionSet",

--- a/src/aws/osml/photogrammetry/elevation_model.py
+++ b/src/aws/osml/photogrammetry/elevation_model.py
@@ -1,6 +1,20 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
 
 from .coordinates import GeodeticWorldCoordinate
+
+
+@dataclass
+class ElevationRegionSummary:
+    """
+    This class contains a general summary of an elevation tile.
+    """
+
+    min_elevation: float
+    max_elevation: float
+    no_data_value: int
+    post_spacing: float
 
 
 class ElevationModel(ABC):
@@ -22,6 +36,15 @@ class ElevationModel(ABC):
         :param world_coordinate: the coordinate to update
 
         :return: None
+        """
+
+    @abstractmethod
+    def describe_region(self, world_coordinate: GeodeticWorldCoordinate) -> Optional[ElevationRegionSummary]:
+        """
+        Get a summary of the region near the provided world coordinate
+
+        :param world_coordinate: the coordinate at the center of the region of interest
+        :return: the summary information
         """
 
 
@@ -50,3 +73,17 @@ class ConstantElevationModel(ElevationModel):
         :return: None
         """
         world_coordinate.elevation = self.constant_elevation
+
+    def describe_region(self, world_coordinate: GeodeticWorldCoordinate) -> Optional[ElevationRegionSummary]:
+        """
+        Get a summary of the region near the provided world coordinate
+
+        :param world_coordinate: the coordinate at the center of the region of interest
+        :return: [min elevation value, max elevation value, no elevation data value, post spacing]
+        """
+        return ElevationRegionSummary(
+            min_elevation=self.constant_elevation,
+            max_elevation=self.constant_elevation,
+            no_data_value=-32767,
+            post_spacing=30.0,
+        )

--- a/test/aws/osml/gdal/test_gdal_dem_tile_factory.py
+++ b/test/aws/osml/gdal/test_gdal_dem_tile_factory.py
@@ -21,7 +21,7 @@ class TestGDALDemTileFactory(TestCase):
         from aws.osml.photogrammetry import GeodeticWorldCoordinate
 
         tile_factory = GDALDigitalElevationModelTileFactory("./test/data")
-        elevation_array, sensor_model = tile_factory.get_tile("n47_e034_3arc_v2.tif")
+        elevation_array, sensor_model, summary = tile_factory.get_tile("n47_e034_3arc_v2.tif")
 
         assert elevation_array is not None
         assert elevation_array.shape == (1201, 1201)
@@ -31,6 +31,12 @@ class TestGDALDemTileFactory(TestCase):
 
         assert center_image.x == pytest.approx(600.5, abs=1.0)
         assert center_image.y == pytest.approx(600.5, abs=1.0)
+
+        assert summary.min_elevation == -1.0
+        assert summary.max_elevation == 152.0
+        assert summary.no_data_value == -32767
+        # The 3-arc second test file used here is somewhere around 90 meter resolution
+        assert abs(90.0 - summary.post_spacing) < 20.0
 
 
 if __name__ == "__main__":

--- a/test/aws/osml/gdal/test_sensor_model_factory.py
+++ b/test/aws/osml/gdal/test_sensor_model_factory.py
@@ -185,11 +185,11 @@ class TestSensorModelFactory(TestCase):
 
             scp_image_coord = ImageCoordinate(
                 [
-                    sm.image_plane.scp_pixel.x - sm.image_plane.first_pixel.x,
-                    sm.image_plane.scp_pixel.y - sm.image_plane.first_pixel.y,
+                    sm.coord_converter.scp_pixel.x - sm.coord_converter.first_pixel.x,
+                    sm.coord_converter.scp_pixel.y - sm.coord_converter.first_pixel.y,
                 ]
             )
-            scp_world_coord = geocentric_to_geodetic(sm.image_plane.scp_ecf)
+            scp_world_coord = geocentric_to_geodetic(sm.coord_converter.scp_ecf)
 
             assert np.allclose(scp_image_coord.coordinate, sm.world_to_image(scp_world_coord).coordinate, atol=1.0)
 

--- a/test/aws/osml/photogrammetry/test_digital_elevation_model.py
+++ b/test/aws/osml/photogrammetry/test_digital_elevation_model.py
@@ -13,6 +13,7 @@ class TestDigitalElevationModel(unittest.TestCase):
             DigitalElevationModelTileFactory,
             DigitalElevationModelTileSet,
         )
+        from aws.osml.photogrammetry.elevation_model import ElevationRegionSummary
         from aws.osml.photogrammetry.sensor_model import SensorModel
 
         mock_tile_set = mock.Mock(DigitalElevationModelTileSet)
@@ -20,6 +21,7 @@ class TestDigitalElevationModel(unittest.TestCase):
 
         # This is a sample 3x3 grid of elevation data
         test_elevation_data = np.array([[0.0, 1.0, 4.0], [1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
+        test_elevation_summary = ElevationRegionSummary(0.0, 4.0, -1, 30.0)
 
         # These are the points we will test for interpolation
         test_grid_coordinates = [
@@ -44,7 +46,7 @@ class TestDigitalElevationModel(unittest.TestCase):
 
         # This mock tile factory will always return the 3x3 elevation grid and the sensor model
         mock_tile_factory = mock.Mock(DigitalElevationModelTileFactory)
-        mock_tile_factory.get_tile.return_value = test_elevation_data, mock_sensor_model
+        mock_tile_factory.get_tile.return_value = test_elevation_data, mock_sensor_model, test_elevation_summary
 
         dem = DigitalElevationModel(mock_tile_set, mock_tile_factory)
 
@@ -96,7 +98,7 @@ class TestDigitalElevationModel(unittest.TestCase):
         mock_tile_set = mock.Mock(DigitalElevationModelTileSet)
         mock_tile_set.find_tile_id.return_value = "MockN00E000V0.tif"
         mock_tile_factory = mock.Mock(DigitalElevationModelTileFactory)
-        mock_tile_factory.get_tile.return_value = None, None
+        mock_tile_factory.get_tile.return_value = None, None, None
 
         dem = DigitalElevationModel(mock_tile_set, mock_tile_factory)
 


### PR DESCRIPTION
These changes allow the SICD sensor models to make use of a Digital Elevation Model (DEM) when performing image to world coordinate conversions. These calculations are described in section 10 of the SICD specification. See: https://nsgreg.nga.mil/doc/view?i=5383

In addition to the SICD sensor model updates a new method was added to the elevation model abstraction that allows us to provide summary information about the area around a given world coordinate. This information is currently used by the SICD sensor model to make searching along a terrain surface more efficient but the summary information itself may eventually be useful to other consumers of the abstraction.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
