### PR TITLE
Fix documentation commands for github actions

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,14 +13,15 @@ jobs:
           pip install sphinx
           python -m pip install sphinx-autoapi
           python -m pip install sphinx_rtd_theme
+          python -m pip install tox tox-gh-actions
       - name: Sphinx build
         run: |
-          sphinx-build doc _build
+          tox -e docs
       - name: Deploy
         uses: peaceiris/actions-gh-pages@f09b4d7e2f12f433806a6273c6b0025df1f7859d
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
+          publish_dir: .tox/docs/tmp/html/
           force_orphan: true


### PR DESCRIPTION
**Issue #, if available:** n/a

**Description of changes:**
- Changed the commands to use `tox -e docs` to generate the docs
- Verified it works using my local github account: https://ranbiraulakh.github.io/osml-imagery-toolkit/index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
