### PR TITLE
fix: correct calculation of INCA R/Rdot projection

### DIFF
--- a/src/aws/osml/photogrammetry/sicd_sensor_model.py
+++ b/src/aws/osml/photogrammetry/sicd_sensor_model.py
@@ -484,7 +484,7 @@ class INCAProjectionSet(COAProjectionSet):
         # (2 repeated in v1.3.0 of the spec) Compute the ARP velocity at the time of closest approach
         # and the magnitude of the vector.
         arp_velocity_ca_tgt = self.varp_poly(time_ca_tgt)
-        mag_arp_velocity_ca_tgt = np.sum(arp_velocity_ca_tgt, axis=-1)
+        mag_arp_velocity_ca_tgt = np.linalg.norm(arp_velocity_ca_tgt)
 
         # (3) Compute the Doppler Rate Scale Factor (drsf_tgt) for image grid location (rg, az).
         drsf_tgt = self.drate_sf_poly(rg, az)

--- a/test/aws/osml/photogrammetry/test_sicd_sensor_model.py
+++ b/test/aws/osml/photogrammetry/test_sicd_sensor_model.py
@@ -159,6 +159,33 @@ class TestSICDSensorModel(unittest.TestCase):
 
         assert np.allclose(calculated_image_scp.coordinate, scp_pixel.coordinate)
 
+        for icp in sicd.geo_data.image_corners.icp:
+            geo_point = GeodeticWorldCoordinate([radians(icp.lon), radians(icp.lat), sicd.geo_data.scp.llh.hae])
+
+            if icp.index == sicd121.CornerStringType.FRFC_1:
+                image_point = ImageCoordinate([sicd.image_data.first_col, sicd.image_data.first_row])
+            elif icp.index == sicd121.CornerStringType.FRLC_2:
+                image_point = ImageCoordinate(
+                    [sicd.image_data.first_col + sicd.image_data.num_cols, sicd.image_data.first_row]
+                )
+            elif icp.index == sicd121.CornerStringType.LRLC_3:
+                image_point = ImageCoordinate(
+                    [
+                        sicd.image_data.first_col + sicd.image_data.num_cols,
+                        sicd.image_data.first_row + sicd.image_data.num_rows,
+                    ]
+                )
+            elif icp.index == sicd121.CornerStringType.LRFC_4:
+                image_point = ImageCoordinate(
+                    [sicd.image_data.first_col, sicd.image_data.first_row + sicd.image_data.num_rows]
+                )
+            else:
+                # Unknown image corner
+                assert False
+
+            new_geo_point = sicd_sensor_model.image_to_world(image_point)
+            assert np.allclose(new_geo_point.coordinate[0:2], geo_point.coordinate[0:2], atol=0.00001)
+
     def test_rgazim_pfa(self):
         sicd: sicd121.SICD = XmlParser().from_path(Path("./test/data/sicd/example.sicd121.pfa.xml"))
 


### PR DESCRIPTION
This change fixes an error in the SICD sensor model INCA R/Rdot projection that was uncovered during integration testing. Unit tests have been updated as well to cover this case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
