### PR TITLE
feat: enable RSM sensor model by default

### DIFF
--- a/src/aws/osml/gdal/gdal_utils.py
+++ b/src/aws/osml/gdal/gdal_utils.py
@@ -50,8 +50,7 @@ def load_gdal_dataset(image_path: str) -> Tuple[gdal.Dataset, Optional[SensorMod
         SensorModelTypes.PROJECTIVE,
         SensorModelTypes.RPC,
         SensorModelTypes.SICD,
-        # TODO: Enable RSM model once testing complete
-        # SensorModelTypes.RSM,
+        SensorModelTypes.RSM,
     ]
     # Create the best sensor model available
     sensor_model = SensorModelFactory(


### PR DESCRIPTION
This change enables the RSM sensor models by default for users loading imagery with load_gdal_dataset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
