### PR TITLE
feat: gdal sensor model now supports non-wgs84 crs

### DIFF
--- a/src/aws/osml/gdal/gdal_sensor_model_builder.py
+++ b/src/aws/osml/gdal/gdal_sensor_model_builder.py
@@ -13,16 +13,18 @@ class GDALAffineSensorModelBuilder(SensorModelBuilder):
     This builder is used to create sensor models for images that have GDAL geo transforms.
     """
 
-    def __init__(self, geo_transform: List[float]) -> None:
+    def __init__(self, geo_transform: List[float], proj_wkt: Optional[str] = None) -> None:
         """
         Constructor for the builder accepting the required GDAL geotransform.
 
         :param geo_transform: the geotransform for this image
+        :param proj_wkt: the well known text string of the CRS used by the image
 
         :return: None
         """
         super().__init__()
         self.geo_transform = geo_transform
+        self.proj_wkt = proj_wkt
 
     def build(self) -> Optional[GDALAffineSensorModel]:
         """
@@ -32,7 +34,7 @@ class GDALAffineSensorModelBuilder(SensorModelBuilder):
         """
         if self.geo_transform is None:
             return None
-        return GDALAffineSensorModel(self.geo_transform)
+        return GDALAffineSensorModel(self.geo_transform, self.proj_wkt)
 
 
 class GDALGCPSensorModelBuilder(SensorModelBuilder):

--- a/src/aws/osml/gdal/gdal_utils.py
+++ b/src/aws/osml/gdal/gdal_utils.py
@@ -35,6 +35,7 @@ def load_gdal_dataset(image_path: str) -> Tuple[gdal.Dataset, Optional[SensorMod
     # Get a GDAL Geo Transform and any available GCPs
     geo_transform = ds.GetGeoTransform(can_return_null=True)
     ground_control_points = ds.GetGCPs()
+    proj_wkt = ds.GetProjection()
 
     # If this image has NITF TREs defined parse them
     parsed_tres = None
@@ -59,6 +60,7 @@ def load_gdal_dataset(image_path: str) -> Tuple[gdal.Dataset, Optional[SensorMod
         xml_tres=parsed_tres,
         xml_dess=xml_dess,
         geo_transform=geo_transform,
+        proj_wkt=proj_wkt,
         ground_control_points=ground_control_points,
         selected_sensor_model_types=selected_sensor_model_types,
     ).build()

--- a/src/aws/osml/gdal/sensor_model_factory.py
+++ b/src/aws/osml/gdal/sensor_model_factory.py
@@ -80,6 +80,7 @@ class SensorModelFactory:
         xml_tres: Optional[ET.Element] = None,
         xml_dess: Optional[List[str]] = None,
         geo_transform: Optional[List[float]] = None,
+        proj_wkt: Optional[str] = None,
         ground_control_points: Optional[List[gdal.GCP]] = None,
         selected_sensor_model_types: Optional[List[SensorModelTypes]] = None,
     ) -> None:
@@ -93,6 +94,7 @@ class SensorModelFactory:
         :param xml_tres: XML representing metadata in the tagged record extensions(TRE)
         :param xml_dess: XML representing data contained in the data extension segments (DES)
         :param geo_transform: a GDAL affine transform
+        :param proj_wkt: the well known text string of the CRS used by the image
         :param ground_control_points: a list of GDAL GCPs that identify correspondences in the image
         :param selected_sensor_model_types: a list of sensor models that should be attempted by this factory
 
@@ -105,6 +107,7 @@ class SensorModelFactory:
         self.xml_tres = xml_tres
         self.xml_dess = xml_dess
         self.geo_transform = geo_transform
+        self.proj_wkt = proj_wkt
         self.ground_control_points = ground_control_points
         self.selected_sensor_model_types = selected_sensor_model_types
 
@@ -121,7 +124,7 @@ class SensorModelFactory:
 
         if SensorModelTypes.AFFINE in self.selected_sensor_model_types:
             if self.geo_transform is not None:
-                approximate_sensor_model = GDALAffineSensorModelBuilder(self.geo_transform).build()
+                approximate_sensor_model = GDALAffineSensorModelBuilder(self.geo_transform, self.proj_wkt).build()
 
         if SensorModelTypes.PROJECTIVE in self.selected_sensor_model_types:
             if self.ground_control_points is not None and len(self.ground_control_points) > 3:


### PR DESCRIPTION
These changes update the GDAL SensorModel so it works with CRSs other than WGS84.

These updates read the projection well known text from the dataset (if available) and pass it into the sensor model which then uses [PyProj](https://pypi.org/project/pyproj/) for transformations between the image CRS to WGS84 as needed. The toolkit's APIs remain unchanged and WGS84 is still used for all WorldCoordinates but this change will allow the toolkit to work with a wider collection of GeoTIFF images. 

    from osgeo import gdal
    from aws.osml.gdal import load_gdal_dataset
    from aws.osml.photogrammetry import ImageCoordinate
    from math import degrees
    
    ds, sm = load_gdal_dataset("./OF6i0_37_000_10836703_20210129_0308R0.tiff")
    width = ds.RasterXSize
    height = ds.RasterYSize
    
    for test_coordinate in [[0, 0], [0, height], [width, 0], [width, height], [width/2, height/2]]:
        world_coordinate = sm.image_to_world(ImageCoordinate(test_coordinate))
        print(world_coordinate.to_dms_string())

Result:

> 344646N0792758W
344556N0792758W
344646N0792658W
344556N0792658W
344621N0792728W

Expected Values:
> Corner Coordinates:
Upper Left  ( 1860000.000,  375000.000) ( 79d27'58.47"W, 34d46'46.09"N)
Lower Left  ( 1860000.000,  370000.000) ( 79d27'58.19"W, 34d45'56.63"N)
Upper Right ( 1865000.000,  375000.000) ( 79d26'58.53"W, 34d46'46.32"N)
Lower Right ( 1865000.000,  370000.000) ( 79d26'58.25"W, 34d45'56.86"N)
Center      ( 1862500.000,  372500.000) ( 79d27'28.36"W, 34d46'21.48"N)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
