### PR TITLE
fix: memory leak and GeoTIFF PROJ errors in v1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = osml-imagery-toolkit
-version = 1.1.0
+version = 1.1.1
 description = Toolkit to work with imagery collected by satellites and UAVs
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/aws/osml/image_processing/gdal_tile_factory.py
+++ b/src/aws/osml/image_processing/gdal_tile_factory.py
@@ -111,12 +111,18 @@ class GDALTileFactory:
         )
 
         # Read the VSIFile
-        vsifile_handle = gdal.VSIFOpenL(temp_ds_name, "r")
-        if vsifile_handle is None:
-            return None
-        stat = gdal.VSIStatL(temp_ds_name, gdal.VSI_STAT_SIZE_FLAG)
-        vsibuf = gdal.VSIFReadL(1, stat.size, vsifile_handle)
-        return vsibuf
+        vsifile_handle = None
+        try:
+            vsifile_handle = gdal.VSIFOpenL(temp_ds_name, "r")
+            if vsifile_handle is None:
+                return None
+            stat = gdal.VSIStatL(temp_ds_name, gdal.VSI_STAT_SIZE_FLAG)
+            vsibuf = gdal.VSIFReadL(1, stat.size, vsifile_handle)
+            return vsibuf
+        finally:
+            if vsifile_handle is not None:
+                gdal.VSIFCloseL(vsifile_handle)
+            gdal.GetDriverByName(self.tile_format).Delete(temp_ds_name)
 
     def create_new_igeolo(self, src_window: List[int]) -> str:
         """

--- a/src/aws/osml/photogrammetry/gdal_sensor_model.py
+++ b/src/aws/osml/photogrammetry/gdal_sensor_model.py
@@ -52,7 +52,9 @@ class GDALAffineSensorModel(SensorModel):
 
             self.image_to_wgs84 = None
             if proj_wkt:
-                self.image_to_wgs84 = pyproj.Transformer.from_crs(pyproj.CRS.from_string(proj_wkt), LLA_PROJ.crs)
+                self.image_to_wgs84 = pyproj.Transformer.from_crs(
+                    pyproj.CRS.from_string(proj_wkt), LLA_PROJ.crs, always_xy=True
+                )
 
         except np.linalg.LinAlgError:
             raise ValueError("GeoTransform can not be inverted. Not a valid matrix for a sensor model.")


### PR DESCRIPTION
This PR includes the following changes:

- Fix a memory leak caused by not deleting the temporary [GDAL vsimem virtual file system](https://gdal.org/user/virtual_file_systems.html#vsimem-in-memory-files) created for each tile by the GDALTileFactory. 
- Fix a bug in the coordinate ordering for GEOGCS coordinate conversions. The original code did not account for the reversal of the (long, lat) coordinate. Using the [always_xy](https://pyproj4.github.io/pyproj/stable/api/transformer.html) flag on the PROJ Transformer will keep everything consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
