### PR TITLE
fix: errors constructing RSMSectionedPolynomialSensorModel from TREs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = osml-imagery-toolkit
-version = 1.1.1
+version = 1.1.2
 description = Toolkit to work with imagery collected by satellites and UAVs
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/aws/osml/gdal/rsm_sensor_model_builder.py
+++ b/src/aws/osml/gdal/rsm_sensor_model_builder.py
@@ -280,7 +280,7 @@ class RSMSensorModelBuilder(SensorModelBuilder):
 
         coefficients = []
         for coeff_suffix in ["0", "X", "Y", "Z", "XX", "XY", "XZ", "YY", "YZ", "ZZ"]:
-            coefficients.append(get_tre_field_value(rsmpi_tre, f"{polynomial_prefix}{coeff_suffix}", int))
+            coefficients.append(get_tre_field_value(rsmpi_tre, f"{polynomial_prefix}{coeff_suffix}", float))
         return RSMLowOrderPolynomial(coefficients)
 
     @staticmethod
@@ -306,9 +306,9 @@ class RSMSensorModelBuilder(SensorModelBuilder):
             sensor_model_grid_map[(sensor_model.section_row, sensor_model.section_col)] = sensor_model
 
         section_sensor_model_grid = []
-        for row in range(0, num_section_rows):
+        for row in range(1, num_section_rows + 1):
             row_of_sensor_models = []
-            for col in range(0, num_section_cols):
+            for col in range(1, num_section_cols + 1):
                 row_of_sensor_models.append(sensor_model_grid_map[(row, col)])
             section_sensor_model_grid.append(row_of_sensor_models)
 


### PR DESCRIPTION
These changes fix errors in how RSMSectionedPolynomialSensorModels are constructed from TREs. 

- The floating point coefficients of the low order polynomial were incorrectly being transformed to int which caused ValueErrors. 
- The first section row/column numbers start at 1 not 0 so the code constructing the array of section sensor models needed to be updated to match.
- We will release these fixes as an immediate `PATCH` release so the library version number has been incremented to 1.1.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
