### PR TITLE
feat: adds generic DEM tile set and geodetic coordinate formatting

### DIFF
--- a/src/aws/osml/photogrammetry/__init__.py
+++ b/src/aws/osml/photogrammetry/__init__.py
@@ -18,6 +18,7 @@ from .coordinates import (
 from .digital_elevation_model import DigitalElevationModel, DigitalElevationModelTileFactory, DigitalElevationModelTileSet
 from .elevation_model import ConstantElevationModel, ElevationModel, ElevationRegionSummary
 from .gdal_sensor_model import GDALAffineSensorModel
+from .generic_dem_tile_set import GenericDEMTileSet
 from .projective_sensor_model import ProjectiveSensorModel
 from .replacement_sensor_model import (
     RSMContext,
@@ -59,6 +60,7 @@ __all__ = [
     "ElevationModel",
     "ElevationRegionSummary",
     "GDALAffineSensorModel",
+    "GenericDEMTileSet",
     "SARImageCoordConverter",
     "INCAProjectionSet",
     "PlaneProjectionSet",

--- a/src/aws/osml/photogrammetry/coordinates.py
+++ b/src/aws/osml/photogrammetry/coordinates.py
@@ -6,14 +6,9 @@ from pyproj.enums import TransformDirection
 
 class WorldCoordinate:
     """
-    A world coordinate is a vector representing a position in 3D space. The ground coordinate system specified is
-    either Geodetic (latitude, longitude, and height above the WGS 84 reference ellipsoid), or Rectangular (cartesian
-    coordinates in reference to a local tangent plane). Regardless whether the coordinate system is specified as
-    Geodetic or Rectangular, associated ground point locations are represented as a triple – x, y, and z.
-
-    A Rectangular system should be specified when the image footprint is near the earth’s North or South Pole. Either
-    a Rectangular or Geodetic system can be specified when the footprint is near 180 degrees East longitude. However,
-    if Geodetic, the range for longitude is then specified as (0,2pi) radians instead of the usual (-pi, +pi) radians.
+    A world coordinate is a vector representing a position in 3D space. Note that this type is a simple value with
+    3 components that does not distinguish between geodetic or other cartesian coordinate systems (e.g. geocentric
+    Earth-Centered Earth-Fixed or coordinates based on a local tangent plane).
     """
 
     def __init__(self, coordinate: npt.ArrayLike = None) -> None:
@@ -57,11 +52,50 @@ class WorldCoordinate:
     def z(self, value: float) -> None:
         self.coordinate[2] = value
 
+    def __repr__(self):
+        return f"WorldCoordinate(coordinate={np.array_repr(self.coordinate)})"
+
 
 class GeodeticWorldCoordinate(WorldCoordinate):
     """
     A GeodeticWorldCoordinate is an WorldCoordinate where the x,y,z components can be interpreted as longitude,
-    latitude, and elevation.
+    latitude, and elevation. It is important to note that longitude, and latitude are in radians while elevation
+    is meters above the ellipsoid.
+
+    This class uses a custom format specification for a geodetic coordinate uses % directives similar to datetime.
+    These custom directives can be combined as needed with literal values to produce a wide
+    range of output formats. For example, '%ld%lm%ls%lH%od%om%os%oh' will produce a ddmmssXdddmmssY formatted
+    coordinate. The first half, ddmmssX, represents degrees, minutes, and seconds of latitude with X representing
+    North or South (N for North, S for South). The second half, dddmmssY, represents degrees, minutes, and seconds
+    of longitude with Y representing East or West (E for East, W for West), respectively.
+
+
+    ========= ================================================ =====
+    Directive Meaning                                          Notes
+    ========= ================================================ =====
+    %L        latitude in decimal radians                       1
+    %l        latitude in decimal degrees                       1
+    %ld       latitute degrees                                  2
+    %lm       latitude minutes
+    %ls       latitude seconds
+    %lh       latitude hemisphere (n or s)
+    %lH       latitude hemisphere uppercase (N or S)
+    %O        longitude in decimal radians                      1
+    %o        longitude in decimal degrees                      1
+    %od       longitude degrees                                 2
+    %om       longitude minutes
+    %os       longitude seconds
+    %oh       longitude hemisphere (e or w)
+    %oH       longitude hemisphere uppercase (E or W)
+    %E        elevation in meters
+    %%        used to represent a literal % in the output
+    ========= ================================================ =====
+
+    Notes:
+
+    #. Formatting in decimal degrees or radians will be signed values
+    #. Formatting for the degrees, minutes, seconds will always be unsigned assuming hemisphere will be included
+    #. Any unknown directives will be ignored
     """
 
     def __init__(self, coordinate: npt.ArrayLike = None) -> None:
@@ -109,34 +143,85 @@ class GeodeticWorldCoordinate(WorldCoordinate):
 
         :return: the formatted coordinate string
         """
-        result_parts = []
+        return f"{self:%ld%lm%ls%lH%od%om%os%oH}"
+
+    def __repr__(self):
+        return f"GeodeticWorldCoordinate(coordinate={np.array_repr(self.coordinate)})"
+
+    def __format__(self, format_spec: str) -> str:
+        if format_spec is None or format_spec == "":
+            format_spec = "%ld%lm%ls%lH %od%om%os%oH %E"
+
         lat_degrees = np.degrees(self.latitude)
-        direction = "N"
+        lh = "N"
         if lat_degrees < 0:
             lat_degrees *= -1.0
-            direction = "S"
-        d = int(lat_degrees)
-        m = int(round(lat_degrees - d, 6) * 60)
-        s = int(round(lat_degrees - d - m / 60, 6) * 3600)
-        result_parts.append(format(d, "02d"))
-        result_parts.append(format(m, "02d"))
-        result_parts.append(format(s, "02d"))
-        result_parts.append(direction)
+            lh = "S"
+        ld = int(lat_degrees)
+        lm = int(round(lat_degrees - ld, 6) * 60)
+        ls = int(round(lat_degrees - ld - lm / 60, 6) * 3600)
 
         lon_degrees = np.degrees(self.longitude)
-        direction = "E"
+        oh = "E"
         if lon_degrees < 0:
             lon_degrees *= -1.0
-            direction = "W"
-        d = int(lon_degrees)
-        m = int(round(lon_degrees - d, 6) * 60)
-        s = int(round(lon_degrees - d - m / 60, 6) * 3600)
-        result_parts.append(format(d, "03d"))
-        result_parts.append(format(m, "02d"))
-        result_parts.append(format(s, "02d"))
-        result_parts.append(direction)
+            oh = "W"
+        od = int(lon_degrees)
+        om = int(round(lon_degrees - od, 6) * 60)
+        os = int(round(lon_degrees - od - om / 60, 6) * 3600)
 
-        return "".join(result_parts)
+        result = []
+        i = 0
+        while i < len(format_spec):
+            if format_spec[i] == "%" and (i + 1) < len(format_spec):
+                i += 1
+                directive = format_spec[i]
+                if directive == "L":
+                    result.append(str(self.latitude))
+                elif directive == "O":
+                    result.append(str(self.longitude))
+                elif directive == "l":
+                    if (i + 1) < len(format_spec) and format_spec[i + 1] in ["d", "m", "s", "h", "H"]:
+                        i += 1
+                        part = format_spec[i]
+                        if part == "d":
+                            result.append(format(ld, "02d"))
+                        elif part == "m":
+                            result.append(format(lm, "02d"))
+                        elif part == "s":
+                            result.append(format(ls, "02d"))
+                        elif part == "h":
+                            result.append(lh.lower())
+                        else:
+                            # part must equal 'H'
+                            result.append(lh)
+                    else:
+                        result.append(str(lat_degrees))
+                elif directive == "o":
+                    if (i + 1) < len(format_spec) and format_spec[i + 1] in ["d", "m", "s", "h", "H"]:
+                        i += 1
+                        part = format_spec[i]
+                        if part == "d":
+                            result.append(format(od, "03d"))
+                        elif part == "m":
+                            result.append(format(om, "02d"))
+                        elif part == "s":
+                            result.append(format(os, "02d"))
+                        elif part == "h":
+                            result.append(oh.lower())
+                        else:
+                            # part must equal 'H'
+                            result.append(oh)
+                    else:
+                        result.append(str(lon_degrees))
+                elif directive == "E":
+                    result.append(str(self.elevation))
+                elif directive == "%":
+                    result.append("%")
+            else:
+                result.append(format_spec[i])
+            i += 1
+        return "".join(result)
 
 
 # These are common definitions of projections used by Pyproj. They are used when converting between an Earth Centered
@@ -248,3 +333,6 @@ class ImageCoordinate:
     @y.setter
     def y(self, value: float) -> None:
         self.r = value
+
+    def __repr__(self):
+        return f"ImageCoordinate(coordinate={np.array_repr(self.coordinate)})"

--- a/src/aws/osml/photogrammetry/generic_dem_tile_set.py
+++ b/src/aws/osml/photogrammetry/generic_dem_tile_set.py
@@ -1,0 +1,53 @@
+from math import degrees, floor
+from typing import Optional
+
+from .coordinates import GeodeticWorldCoordinate
+from .digital_elevation_model import DigitalElevationModelTileSet
+
+
+class GenericDEMTileSet(DigitalElevationModelTileSet):
+    """
+    A generalizable tile set with a naming convention that can be described as a format string.
+    """
+
+    def __init__(self, format_spec: str = "%od%oh/%ld%lh.dt2",
+                 min_latitude_degrees: float = -90.0,
+                 max_latitude_degrees: float = 90.0,
+                 min_longitude_degrees: float = -180.0,
+                 max_longitude_degrees: float = 180.0) -> None:
+        """
+        Construct a tile set from a limited collection of configurable parameters. This implementation uses the
+        custom formatting directives supplied with GeodeticWorldCoordinate to allow users to create tile IDs
+        that match a variety of situations. For example the default format_spec of '%od%oh/%ld%lh.dt2' will
+        generate tile ids like: '115e/45s.dt2' which would match some common 1-degree cell based DEM file
+        hierarchies.
+
+        :param format_spec: the format specification for the GeodeteticWorldCoordinate
+
+
+        :return: None
+        """
+        super().__init__()
+        self.format_string = format_spec
+        self.min_latitude_degrees = min_latitude_degrees
+        self.max_latitude_degrees = max_latitude_degrees
+        self.min_longitude_degrees = min_longitude_degrees
+        self.max_longitude_degrees = max_longitude_degrees
+
+    def find_tile_id(self, geodetic_world_coordinate: GeodeticWorldCoordinate) -> Optional[str]:
+        """
+        This method creates tile IDs that based on the format string provided.
+
+        :param geodetic_world_coordinate: the world coordinate of interest
+
+        :return: the tile path or None if the DEM does not have coverage for this location
+        """
+        longitude_degrees = floor(degrees(geodetic_world_coordinate.longitude))
+        latitude_degrees = floor(degrees(geodetic_world_coordinate.latitude))
+
+        # The SRTM mission only covers latitudes N59 through S56 so if the requested location is outside those
+        # ranges we know there is no file available for it.
+        if latitude_degrees > self.max_latitude_degrees or latitude_degrees < self.min_latitude_degrees or longitude_degrees > self.max_longitude_degrees or longitude_degrees < self.min_longitude_degrees:
+            return None
+
+        return f"{geodetic_world_coordinate:{self.format_string}}"

--- a/src/aws/osml/photogrammetry/generic_dem_tile_set.py
+++ b/src/aws/osml/photogrammetry/generic_dem_tile_set.py
@@ -10,11 +10,14 @@ class GenericDEMTileSet(DigitalElevationModelTileSet):
     A generalizable tile set with a naming convention that can be described as a format string.
     """
 
-    def __init__(self, format_spec: str = "%od%oh/%ld%lh.dt2",
-                 min_latitude_degrees: float = -90.0,
-                 max_latitude_degrees: float = 90.0,
-                 min_longitude_degrees: float = -180.0,
-                 max_longitude_degrees: float = 180.0) -> None:
+    def __init__(
+        self,
+        format_spec: str = "%od%oh/%ld%lh.dt2",
+        min_latitude_degrees: float = -90.0,
+        max_latitude_degrees: float = 90.0,
+        min_longitude_degrees: float = -180.0,
+        max_longitude_degrees: float = 180.0,
+    ) -> None:
         """
         Construct a tile set from a limited collection of configurable parameters. This implementation uses the
         custom formatting directives supplied with GeodeticWorldCoordinate to allow users to create tile IDs
@@ -47,7 +50,12 @@ class GenericDEMTileSet(DigitalElevationModelTileSet):
 
         # The SRTM mission only covers latitudes N59 through S56 so if the requested location is outside those
         # ranges we know there is no file available for it.
-        if latitude_degrees > self.max_latitude_degrees or latitude_degrees < self.min_latitude_degrees or longitude_degrees > self.max_longitude_degrees or longitude_degrees < self.min_longitude_degrees:
+        if (
+            latitude_degrees > self.max_latitude_degrees
+            or latitude_degrees < self.min_latitude_degrees
+            or longitude_degrees > self.max_longitude_degrees
+            or longitude_degrees < self.min_longitude_degrees
+        ):
             return None
 
         return f"{geodetic_world_coordinate:{self.format_string}}"

--- a/test/aws/osml/photogrammetry/test_coordinates.py
+++ b/test/aws/osml/photogrammetry/test_coordinates.py
@@ -14,6 +14,12 @@ class TestCoordinates(unittest.TestCase):
         assert world_coordinate.z == 3.0
         assert world_coordinate.coordinate.shape == (3,)  # 1D numpy array
 
+    def test_worldcoordinate_repr(self):
+        from aws.osml.photogrammetry.coordinates import WorldCoordinate
+
+        world_coordinate = WorldCoordinate([1.0, 2.0, 3.0])
+        assert f"{world_coordinate!r}" == "WorldCoordinate(coordinate=array([1., 2., 3.]))"
+
     def test_imagecoordinate_list_constructor(self):
         from aws.osml.photogrammetry.coordinates import ImageCoordinate
 
@@ -37,6 +43,12 @@ class TestCoordinates(unittest.TestCase):
         with pytest.raises(ValueError) as value_error:
             image_coordinate = ImageCoordinate([1.0, 2.0, 3.0])  # noqa: F841
         assert "must have 2 components" in str(value_error.value)
+
+    def test_imagecoordinate_repr(self):
+        from aws.osml.photogrammetry.coordinates import ImageCoordinate
+
+        image_coordinate = ImageCoordinate([-10.2, 5.0])
+        assert f"{image_coordinate!r}" == "ImageCoordinate(coordinate=array([-10.2,   5. ]))"
 
     def test_geodeticworldcoordinate_list_constructor(self):
         from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
@@ -114,6 +126,23 @@ class TestCoordinates(unittest.TestCase):
         assert geodetic_coordinate.to_dms_string() == "103045S1213045W"
         geodetic_coordinate = GeodeticWorldCoordinate([radians(1.5125), radians(1.5125), 10.0])
         assert geodetic_coordinate.to_dms_string() == "013045N0013045E"
+
+    def test_geodeticworldcoordinate_format(self):
+        from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
+
+        geodetic_coordinate = GeodeticWorldCoordinate([radians(115.25), radians(-45.5), 3.0])
+        assert f"{geodetic_coordinate:%ld%lm%ls%lH %od%om%os%oH %E}" == "453000S 1151500E 3.0"
+        assert f"{geodetic_coordinate:%ld %lm %ls %lh %od %om %os %oh %E}" == "45 30 00 s 115 15 00 e 3.0"
+        assert f"{geodetic_coordinate:%l %o %E}" == "45.5 115.25 3.0"
+        assert f"{geodetic_coordinate:%L %O %E}" == "-0.7941248096574199 2.011491962923465 3.0"
+        assert f"{geodetic_coordinate}" == "453000S 1151500E 3.0"
+        assert f"{geodetic_coordinate:100%% unexpected usage: %X}" == "100% unexpected usage: "
+
+    def test_geodeticworldcoordinate_repr(self):
+        from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
+
+        geodetic_coordinate = GeodeticWorldCoordinate([1.1, 2.2, 3.3])
+        assert f"{geodetic_coordinate!r}" == "GeodeticWorldCoordinate(coordinate=array([1.1, 2.2, 3.3]))"
 
     def test_ecef_to_geodetic(self):
         from aws.osml.photogrammetry.coordinates import WorldCoordinate, geocentric_to_geodetic

--- a/test/aws/osml/photogrammetry/test_generic_dem_tile_set.py
+++ b/test/aws/osml/photogrammetry/test_generic_dem_tile_set.py
@@ -1,0 +1,16 @@
+import unittest
+from math import radians
+
+
+class TestGenericDEMTileSet(unittest.TestCase):
+    def test_default_format_spec(self):
+        from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
+        from aws.osml.photogrammetry.generic_dem_tile_set import GenericDEMTileSet
+
+        tile_set = GenericDEMTileSet()
+        tile_path = tile_set.find_tile_id(GeodeticWorldCoordinate([radians(142), radians(3), 0.0]))
+        assert "142e/03n.dt2" == tile_path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
These changes add a flexible directive based custom formatting for GeodeticWorldCoordinates similar to the datetime type. This allows users to easily generate string representations of their coordinates in decimal degrees, decimal radians, as well as combinations of integer degrees, minutes, seconds, hemisphere fields. This formatting also allowed for a more generic DEM tile set implementation where a user can specify a format string to convert a coordinate into a tile ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
