### PR TITLE
feat: add ability to create scaled tiles and tiles from SIDD

### DIFF
--- a/src/aws/osml/image_processing/sicd_updater.py
+++ b/src/aws/osml/image_processing/sicd_updater.py
@@ -1,14 +1,12 @@
 import logging
-import re
-from typing import Callable, List, TypeVar
-from xml.etree import ElementTree as ET
+from math import floor
+from typing import List, Optional, Tuple
 
-from defusedxml import ElementTree
+from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.serializers import XmlSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
 logger = logging.getLogger(__name__)
-
-# This is a type placeholder needed by the parse_element_text() type hints
-T = TypeVar("T")
 
 
 class SICDUpdater:
@@ -16,30 +14,23 @@ class SICDUpdater:
     This class provides a means to perform common updates to a SICD XML metadata document.
     """
 
-    def __init__(self, sicd_element: ET.Element):
+    def __init__(self, xml_str: str):
         """
         Construct a new instance of this class to manage a given set of SICD metadata.
 
-        :param sicd_element: the SICD XML metadata to update
+        :param xml_str: the SICD XML metadata to update
         """
-        self.sicd_element = sicd_element
-
-        # Extract the XML namespace from the root SICD element and store it for later use in element queries
-        namespace_match = re.match(r"{.*}", self.sicd_element.tag)
-        self.namespace = namespace_match.group(0) if namespace_match else ""
-
-        # We don't currently have many examples of SICD data. An attempt has been made to make this code
-        # work so long as the portions of the XML schema we depend upon don't change. This warning is just
-        # an attempt to provide diagnostic information incase future datasets don't work.
-        if self.namespace != "{urn:SICD:1.2.1}":
-            logger.warning(f"Attempting to process SICD metadata with an untested namespace {self.namespace}")
+        self.xml_str = xml_str
+        if self.xml_str is not None and len(self.xml_str) > 0:
+            parser = XmlParser()
+            self.sicd = parser.from_string(self.xml_str)
 
         # Here we're storing off the original first row/col to support the case where multiple chips are
         # created from a SICD image that has already been chipped.
-        self.original_first_row = self.parse_element_text(".//{0}FirstRow".format(self.namespace), int)
-        self.original_first_col = self.parse_element_text(".//{0}FirstCol".format(self.namespace), int)
+        self.original_first_row = self.sicd.image_data.first_row
+        self.original_first_col = self.sicd.image_data.first_col
 
-    def update_image_data_for_chip(self, chip_bounds: List[int]) -> None:
+    def update_image_data_for_chip(self, chip_bounds: List[int], output_size: Optional[Tuple[int, int]]) -> None:
         """
         This updates the SICD ImageData structure so that the FirstRow, FirstCol and NumRows, NumCols
         elements match the new chip boundary.A sample of this XML structure is shown below::
@@ -57,30 +48,16 @@ class SICDUpdater:
 
 
         :param chip_bounds: the [col, row, width, height] of the chip boundary
+        :param output_size: the [width, height] of the output chip
         """
-        first_col_element = self.sicd_element.find(".//{0}FirstCol".format(self.namespace))
-        first_row_element = self.sicd_element.find(".//{0}FirstRow".format(self.namespace))
-        num_cols_element = self.sicd_element.find(".//{0}NumCols".format(self.namespace))
-        num_rows_element = self.sicd_element.find(".//{0}NumRows".format(self.namespace))
-        if first_row_element is None or first_col_element is None or num_cols_element is None or num_rows_element is None:
-            logger.warning("SICD ImageData structures were not found. No updates applied.")
-            return
 
-        first_col_element.text = str(self.original_first_col + chip_bounds[0])
-        first_row_element.text = str(self.original_first_row + chip_bounds[1])
-        num_cols_element.text = str(chip_bounds[2])
-        num_rows_element.text = str(chip_bounds[3])
+        if output_size is not None and (output_size[0] != chip_bounds[2] or output_size[1] != chip_bounds[3]):
+            raise ValueError("SICD chipping does not support scaling operations.")
 
-        if logger.isEnabledFor(logging.DEBUG):
-            image_data_element = self.sicd_element.find(".//{0}ImageData".format(self.namespace))
-            if image_data_element is not None:
-                logger.debug("Updated SICD ImageData element for chip:")
-                logger.debug(
-                    ElementTree.tostring(
-                        image_data_element,
-                        encoding="unicode",
-                    )
-                )
+        self.sicd.image_data.first_row = floor(float(self.original_first_row)) + int(chip_bounds[1])
+        self.sicd.image_data.first_col = floor(float(self.original_first_col)) + int(chip_bounds[0])
+        self.sicd.image_data.num_rows = int(chip_bounds[3])
+        self.sicd.image_data.num_cols = int(chip_bounds[2])
 
     def encode_current_xml(self) -> str:
         """
@@ -88,21 +65,6 @@ class SICDUpdater:
 
         :return: xml encoded SICD metadata
         """
-        return ElementTree.tostring(self.sicd_element, encoding="unicode")
-
-    def parse_element_text(self, element_xpath: str, type_conversion: Callable[[str], T]) -> T:
-        """
-        This function finds the first element matching the provided xPath and then runs the text of that element
-        through the provided conversion function.
-
-        :param element_xpath: the xPath of the element
-        :param type_conversion: the desired type of the output, must support construction from a string
-        :return: the element text converted to the requested type
-        """
-        field_element = self.sicd_element.find(element_xpath)
-        if field_element is None:
-            raise ValueError(f"Unable to find element {element_xpath}")
-        str_value = field_element.text
-        if str_value is None:
-            raise ValueError(f"Element {element_xpath} does not have text.")
-        return type_conversion(str_value)
+        serializer = XmlSerializer(config=SerializerConfig(pretty_print=False))
+        updated_xml = serializer.render(self.sicd)
+        return updated_xml

--- a/src/aws/osml/image_processing/sidd_updater.py
+++ b/src/aws/osml/image_processing/sidd_updater.py
@@ -1,0 +1,191 @@
+import logging
+from typing import List, Optional, Tuple
+
+from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.serializers import XmlSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
+
+import aws.osml.formats.sidd.models.sidd_v1_0_0 as sidd100
+import aws.osml.formats.sidd.models.sidd_v2_0_0 as sidd200
+import aws.osml.formats.sidd.models.sidd_v3_0_0 as sidd300
+
+logger = logging.getLogger(__name__)
+
+
+class SIDDUpdater:
+    def __init__(self, xml_str: str):
+        """
+        Construct a new instance of this class to manage a given set of SIDD metadata.
+
+        :param xml_str: the SIDD XML metadata to update
+        """
+        self.xml_str = xml_str
+        if self.xml_str is not None and len(self.xml_str) > 0:
+            parser = XmlParser()
+            self.sidd = parser.from_string(self.xml_str)
+
+    def update_image_data_for_chip(self, chip_bounds: List[int], output_size: Optional[Tuple[int, int]]) -> None:
+        """
+        This adds or updates the SIDD GeometricChip structure so that the ChipSize and original corner coordinates
+        are recorded. A sample of this XML structure is shown below:
+
+                <GeometricChip>
+                  <ChipSize>
+                    <Row xmlns:ns1="urn:SICommon:1.0">512</Row>
+                    <Col xmlns:ns1="urn:SICommon:1.0">512</Col>
+                  </ChipSize>
+                  <OriginalUpperLeftCoordinate>
+                    <Row xmlns:ns1="urn:SICommon:1.0">7408</Row>
+                    <Col xmlns:ns1="urn:SICommon:1.0">7407</Col>
+                  </OriginalUpperLeftCoordinate>
+                  <OriginalUpperRightCoordinate>
+                    <Row xmlns:ns1="urn:SICommon:1.0">7408</Row>
+                    <Col xmlns:ns1="urn:SICommon:1.0">7919</Col>
+                  </OriginalUpperRightCoordinate>
+                  <OriginalLowerLeftCoordinate>
+                    <Row xmlns:ns1="urn:SICommon:1.0">7920</Row>
+                    <Col xmlns:ns1="urn:SICommon:1.0">7407</Col>
+                  </OriginalLowerLeftCoordinate>
+                  <OriginalLowerRightCoordinate>
+                    <Row xmlns:ns1="urn:SICommon:1.0">7920</Row>
+                    <Col xmlns:ns1="urn:SICommon:1.0">7919</Col>
+                  </OriginalLowerRightCoordinate>
+                </GeometricChip>
+
+
+        :param chip_bounds: the [col, row, width, height] of the chip boundary
+        :param output_size: the [width, height] of the output chip if different from the chip boundary
+        """
+        if not output_size:
+            output_size = chip_bounds[2], chip_bounds[3]
+
+        # The xsdata code generators produced different types for each version of the SIDD specification.
+        # in this case the types are all equivalent so the logic isn't different but this piece of code
+        # ensures we're constructing the correct type from the right version of SIDD constructs.
+        if isinstance(self.sidd, sidd100.SIDD):
+            sidd_namespace = sidd100
+        elif isinstance(self.sidd, sidd200.SIDD):
+            sidd_namespace = sidd200
+        elif isinstance(self.sidd, sidd300.SIDD):
+            sidd_namespace = sidd300
+        else:
+            logger.warning("sidd_updater.py has not been updated to support a new SIDD version. Defaulting to 3.0")
+            sidd_namespace = sidd300
+
+        # The DownstreamReprocessing element is optional so if it is not set create it first.
+        if not self.sidd.downstream_reprocessing:
+            self.sidd.downstream_reprocessing = sidd_namespace.DownstreamReprocessingType()
+
+        # Identify the location of the UL, UR, LR, LL corners of this chip in the full image. If the image is already
+        # a chip of a full image these coordinates need to be updated, so they are still the positions of the new chip
+        # in the original full image.
+        full_image_chip_corners = [
+            (chip_bounds[0], chip_bounds[1]),
+            (chip_bounds[0] + chip_bounds[2] - 1, chip_bounds[1]),
+            (chip_bounds[0] + chip_bounds[2] - 1, chip_bounds[1] + chip_bounds[3] - 1),
+            (chip_bounds[0], chip_bounds[1] + chip_bounds[3] - 1),
+        ]
+        if self.sidd.downstream_reprocessing.geometric_chip:
+            original_chip_size = (
+                self.sidd.downstream_reprocessing.geometric_chip.chip_size.col,
+                self.sidd.downstream_reprocessing.geometric_chip.chip_size.row,
+            )
+            original_corners = [
+                (
+                    self.sidd.downstream_reprocessing.geometric_chip.original_upper_left_coordinate.col,
+                    self.sidd.downstream_reprocessing.geometric_chip.original_upper_left_coordinate.row,
+                ),
+                (
+                    self.sidd.downstream_reprocessing.geometric_chip.original_upper_right_coordinate.col,
+                    self.sidd.downstream_reprocessing.geometric_chip.original_upper_right_coordinate.row,
+                ),
+                (
+                    self.sidd.downstream_reprocessing.geometric_chip.original_lower_right_coordinate.col,
+                    self.sidd.downstream_reprocessing.geometric_chip.original_lower_right_coordinate.row,
+                ),
+                (
+                    self.sidd.downstream_reprocessing.geometric_chip.original_lower_left_coordinate.col,
+                    self.sidd.downstream_reprocessing.geometric_chip.original_lower_left_coordinate.row,
+                ),
+            ]
+
+            full_image_chip_corners = [
+                SIDDUpdater.chipped_coordinate_to_full(corner, original_chip_size, original_corners)
+                for corner in full_image_chip_corners
+            ]
+
+        # Create the new DownstreamReprocessing.GeometricChip element that contains the information needed to
+        # relate this chip to the original full image.
+        self.sidd.downstream_reprocessing.geometric_chip = sidd_namespace.GeometricChipType(
+            chip_size=sidd_namespace.RowColIntType(row=output_size[1], col=output_size[0]),
+            original_upper_left_coordinate=sidd_namespace.RowColDoubleType(
+                row=full_image_chip_corners[0][1], col=full_image_chip_corners[0][0]
+            ),
+            original_upper_right_coordinate=sidd_namespace.RowColDoubleType(
+                row=full_image_chip_corners[1][1], col=full_image_chip_corners[1][0]
+            ),
+            original_lower_left_coordinate=sidd_namespace.RowColDoubleType(
+                row=full_image_chip_corners[3][1], col=full_image_chip_corners[3][0]
+            ),
+            original_lower_right_coordinate=sidd_namespace.RowColDoubleType(
+                row=full_image_chip_corners[2][1], col=full_image_chip_corners[2][0]
+            ),
+        )
+
+    def encode_current_xml(self) -> str:
+        """
+        Returns a copy of the current SIDD metadata encoded in XML.
+
+        :return: xml encoded SIDD metadata
+        """
+        serializer = XmlSerializer(config=SerializerConfig(pretty_print=False))
+        updated_xml = serializer.render(self.sidd)
+        return updated_xml
+
+    @staticmethod
+    def chipped_coordinate_to_full(
+        chip_coordinate: Tuple[float, float],
+        chip_size: Tuple[int, int],
+        original_corner_coordinates: List[Tuple[float, float]],
+    ) -> Tuple[float, float]:
+        """
+        This function converts pixel locations in a chip to the pixel locations in a full image using a bi-linear
+        interpolation method described in section 5.1.1 of the Sensor Independent Derived Data (SIDD) specification
+        v3.0 Volume 1.
+
+        :param chip_coordinate: the [x, y] coordinate of the pixel in the chip
+        :param chip_size: the size of the chip [width, height]
+        :param original_corner_coordinates: the [x, y] location of the UL, UR, LR, LL corners in the original image
+        :return: the [x, y] coordinate of the pixel in the original image
+        """
+        # Step 1: Normalize the chip coordinates
+        u = chip_coordinate[1] / (chip_size[1] - 1)
+        v = chip_coordinate[0] / (chip_size[0] - 1)
+
+        # Step 2: Compute original full image row coordinate bi-linear coefficients
+        a_r = original_corner_coordinates[0][1]
+        b_r = original_corner_coordinates[3][1] - original_corner_coordinates[0][1]
+        d_r = original_corner_coordinates[1][1] - original_corner_coordinates[0][1]
+        f_r = (
+            original_corner_coordinates[0][1]
+            + original_corner_coordinates[2][1]
+            - original_corner_coordinates[1][1]
+            - original_corner_coordinates[3][1]
+        )
+
+        # Step 3: Compute original full image column coordinate bi-linear coefficients
+        a_c = original_corner_coordinates[0][0]
+        b_c = original_corner_coordinates[3][0] - original_corner_coordinates[0][0]
+        d_c = original_corner_coordinates[1][0] - original_corner_coordinates[0][0]
+        f_c = (
+            original_corner_coordinates[0][0]
+            + original_corner_coordinates[2][0]
+            - original_corner_coordinates[1][0]
+            - original_corner_coordinates[3][0]
+        )
+
+        # Step 4: Compute the full image row and column coordinate
+        r = a_r + u * b_r + v * d_r + u * v * f_r
+        c = a_c + u * b_c + v * d_c + u * v * f_c
+
+        return c, r

--- a/test/data/sidd/umbra-sidd200-chip1.ntf
+++ b/test/data/sidd/umbra-sidd200-chip1.ntf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00d6e8ed7ea4348778ae68d2768b37c11a4f528a1ceb8deb188c7129fa3f5531
+size 283610


### PR DESCRIPTION
These changes add the ability to create scaled tiles using the GDALTileFactory. A new optional ouput_size parameter has been added to create_encoded_tile() that allows a user to select a desired output size. 

These changes also fix a bug that prevented tiles created from a SIDD image from being output as a SIDD chip. The original code had not been updated to correctly update the SIDD XML metadata and instead was trying to use the SICD updater incorrectly. This PR includes a new SIDD metadata updater and it also updated the original SICD metadata updater to use the xsdata generated constructs instead of direct manipulation of ElementTree.

Unit tests were added to exercise the new scaling function and the broken SIDD chipping (which was missing tests). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
