### PR TITLE
fix: pin python version to 3.10 in github workflow steps

### DIFF
--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install sphinx

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Update our GitHub workflows to consistently pin the Python version to 3.10 as part of the setup-python action.
The documentation and publish workflows were updated to be consistent with the tox build which already had the fixed version. This complies with the recommendation on the [setup-python action](https://github.com/marketplace/actions/setup-python):

> The python-version input is optional. If not supplied, the action will try to resolve the version from the default .python-version file. If the .python-version file doesn't exist Python or PyPy version from the PATH will be used. The default version of Python or PyPy in PATH varies between runners and can be changed unexpectedly so we recommend always setting Python version explicitly using the python-version or python-version-file inputs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
