### PR TITLE
build: publish action now tied to release

### DIFF
--- a/.github/workflows/osml-imagery-toolkit-build.yml
+++ b/.github/workflows/osml-imagery-toolkit-build.yml
@@ -2,7 +2,7 @@ name: "OSML Imagery Toolkit Build Workflow"
 
 on:
   pull_request:
-    branches: ["main", "dev"]
+    branches: ["main"]
 
 jobs:
   Build_Validate_Tox:

--- a/.github/workflows/osml-imagery-toolkit-release.yml
+++ b/.github/workflows/osml-imagery-toolkit-release.yml
@@ -1,8 +1,8 @@
 name: "OSML Imagery Toolkit Build and Publish Workflow"
 
 on:
-  push:
-    branches: ["main"]
+  release:
+    types: [published]
 
 jobs:
   Build_Validate_Tox:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,39 +1,32 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Publish Python Package
 
 on:
   workflow_call:
-  release:
-    types: [published]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    environment:
+      name: release
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.8.10
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
Update the GitHub workflow actions to trigger the documentation build and PyPi publish on a release action. See [GitHub Docs Webhook events & Payloads # Release Publish](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release) for additional details.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
