### PR TITLE
docs: add badges and fix broken links in package description

### DIFF
--- a/.github/workflows/osml-imagery-toolkit-build.yml
+++ b/.github/workflows/osml-imagery-toolkit-build.yml
@@ -1,4 +1,4 @@
-name: "OSML Imagery Toolkit Build Workflow"
+name: "build"
 
 on:
   pull_request:

--- a/PACKAGE_DESCRIPTION.md
+++ b/PACKAGE_DESCRIPTION.md
@@ -1,10 +1,3 @@
-# OversightML Imagery Toolkit
-![Build Badge](https://github.com/aws-solutions-library-samples/osml-imagery-toolkit/actions/workflows/osml-imagery-toolkit-build.yml/badge.svg)
-![Python Badge](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11-blue)
-![GitHub License](https://img.shields.io/github/license/aws-solutions-library-samples/osml-imagery-toolkit?color=blue)
-![PyPI - Version](https://img.shields.io/pypi/v/osml-imagery-toolkit)
-
-
 The OversightML Imagery Toolkit is a Python package that contains image processing and photogrammetry routines commonly
 used during the analysis of imagery collected by satellites and unmanned aerial vehicles (UAVs). It builds upon GDAL
 by providing additional support for images compliant with the National Imagery Transmission Format (NITF), Sensor
@@ -19,8 +12,9 @@ This library contains four core packages under the `aws.osml` namespace:
 ## Documentation
 
 * **APIs**: You can find the latest API documentation for the OSML Imagery Toolkit hosted [here](https://aws-solutions-library-samples.github.io/osml-imagery-toolkit/).
-If you are working from the source code running `tox -e docs` will trigger the Sphinx documentation build.
+  If you are working from the source code running `tox -e docs` will trigger the Sphinx documentation build.
 * **Example Notebooks**: Example notebooks for some operations are in the `examples` directory
+
 ## Installation
 
 This software is available through a Python Package Index.
@@ -39,14 +33,5 @@ don't want to use GDAL or those that have their own custom installation steps fo
 this package will include image IO backbones that have fewer dependencies.
 
 ## Contributing
-
-This project welcomes contributions and suggestions. If you would like to submit a pull request, see our
-[Contribution Guide](CONTRIBUTING.md) for more information.
-
-## Security
-
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
-
-## License
-
-This library is licensed under the MIT-0 License. See the [LICENSE](LICENSE) file.
+We welcome contributions and suggestions. If you would like to submit a pull request please do so using a GitHub pull
+request [here](https://github.com/aws-solutions-library-samples/osml-imagery-toolkit/pulls).

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = osml-imagery-toolkit
 version = 1.3.0
 description = Toolkit to work with imagery collected by satellites and UAVs
-long_description = file: README.md
+long_description = file: PACKAGE_DESCRIPTION.md
 long_description_content_type = text/markdown
 author = Amazon Web Services
 author_email = aws-osml-admin@amazon.com

--- a/src/aws/osml/features/__init__.py
+++ b/src/aws/osml/features/__init__.py
@@ -1,16 +1,24 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
 
+# Telling flake8 to not flag errors in this file. It is normal that these classes are imported but not used in an
+# __init__.py file.
+# flake8: noqa
+"""
+The features package contains classes that assist with working with geospatial features derived from imagery.
+
+-------------------------
+
+APIs
+****
+"""
+
 from .feature_index import Feature2DSpatialIndex, STRFeature2DSpatialIndex
 from .geolocation import Geolocator
 from .imaged_feature_property_accessor import ImagedFeaturePropertyAccessor
 
-"""
-The features package contains classes that assist with working with geospatial features derived from imagery.
-"""
-
 __all__ = [
-    "Feature2DSpatialIndex",
     "Geolocator",
     "ImagedFeaturePropertyAccessor",
+    "Feature2DSpatialIndex",
     "STRFeature2DSpatialIndex",
 ]


### PR DESCRIPTION
This change adds common open source shields to our documentation and moved the python pacakge description to a dedicated PACKAGE_DESCRIPTION.md file. The problem with publishing the README.md directly is that when it is pushed to pypi any relative links become broken. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
