### PR TITLE
fix: error creating SICD 1.3.0 sensor models

### DIFF
--- a/src/aws/osml/gdal/sicd_sensor_model_builder.py
+++ b/src/aws/osml/gdal/sicd_sensor_model_builder.py
@@ -138,8 +138,8 @@ class SICDSensorModelBuilder(SensorModelBuilder):
 
         projection_set = None
         ugpn = None
-        if sicd.grid.type_value == sicd121.ImageGridType.RGAZIM:
-            if sicd.image_formation.image_form_algo == sicd121.ImageFormAlgo.PFA:
+        if sicd.grid.type_value.value == sicd121.ImageGridType.RGAZIM.value:
+            if sicd.image_formation.image_form_algo.value == sicd121.ImageFormAlgo.PFA.value:
                 ugpn = xyztype_to_ndarray(sicd.pfa.fpn)
                 projection_set = PFAProjectionSet(
                     scp_ecf=scp_ecf,
@@ -148,11 +148,11 @@ class SICDSensorModelBuilder(SensorModelBuilder):
                     coa_time_poly=time_coa_poly,
                     arp_poly=arp_poly,
                 )
-            elif sicd.image_formation.image_form_algo == sicd121.ImageFormAlgo.RGAZCOMP:
+            elif sicd.image_formation.image_form_algo.value == sicd121.ImageFormAlgo.RGAZCOMP.value:
                 projection_set = RGAZCOMPProjectionSet(
                     scp_ecf=scp_ecf, az_scale_factor=sicd.rg_az_comp.az_sf, coa_time_poly=time_coa_poly, arp_poly=arp_poly
                 )
-        elif sicd.grid.type_value == sicd121.ImageGridType.RGZERO:
+        elif sicd.grid.type_value.value == sicd121.ImageGridType.RGZERO.value:
             projection_set = INCAProjectionSet(
                 r_ca_scp=sicd.rma.inca.r_ca_scp,
                 inca_time_coa_poly=poly1d_to_native(sicd.rma.inca.time_capoly),
@@ -160,10 +160,10 @@ class SICDSensorModelBuilder(SensorModelBuilder):
                 coa_time_poly=time_coa_poly,
                 arp_poly=arp_poly,
             )
-        elif sicd.grid.type_value in [
-            sicd121.ImageGridType.PLANE,
-            sicd121.ImageGridType.XCTYAT,
-            sicd121.ImageGridType.XRGYCR,
+        elif sicd.grid.type_value.value in [
+            sicd121.ImageGridType.PLANE.value,
+            sicd121.ImageGridType.XCTYAT.value,
+            sicd121.ImageGridType.XRGYCR.value,
         ]:
             projection_set = PlaneProjectionSet(
                 scp_ecf=scp_ecf,

--- a/test/aws/osml/gdal/test_sensor_model_factory.py
+++ b/test/aws/osml/gdal/test_sensor_model_factory.py
@@ -176,6 +176,8 @@ class TestSensorModelFactory(TestCase):
             "./test/data/sicd/capella-sicd121-chip1.ntf",
             "./test/data/sicd/capella-sicd121-chip2.ntf",
             "./test/data/sicd/umbra-sicd121-chip1.ntf",
+            "./test/data/sicd/capella-sicd130-chip1.ntf",
+            "./test/data/sicd/capella-sicd130-chip2.ntf",
         ]
         for image_path in test_examples:
             ds = gdal.Open(image_path)

--- a/test/data/sicd/capella-sicd130-chip1.ntf
+++ b/test/data/sicd/capella-sicd130-chip1.ntf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1993e8693fc96961ec4b65dd4ebb7ee975fe63f029a18282396852072ba81c48
+size 1092304

--- a/test/data/sicd/capella-sicd130-chip2.ntf
+++ b/test/data/sicd/capella-sicd130-chip2.ntf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:393a166f78c30cc7ca108306f6e38771feb7c54bced301bdd598b1f73470ed09
+size 1088372


### PR DESCRIPTION
This PR contains a fix that was preventing the toolkit from constructing SICD sensor models from SICD v1.3.0 imagery. The problem was traced to logic that compared the generated enumerated types instead of the actual string values of some key metadata fields. The field values are identical between SICD v1.2.1 and v1.3.0 but the generated class types are not the same.

This issue was confirmed by adding chips of the SICD 1.3.0 images where the problem was encountered to the existing test set to cause failures and then a rerun of those tests with these updates to verify the fix.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
