### PR TITLE
fix: incorrect SICD/SIDD metadata added by tile factory

### DIFF
--- a/src/aws/osml/image_processing/gdal_tile_factory.py
+++ b/src/aws/osml/image_processing/gdal_tile_factory.py
@@ -1,6 +1,7 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
 
 import base64
+import copy
 import logging
 from secrets import token_hex
 from typing import Any, Dict, List, Optional, Tuple
@@ -90,7 +91,7 @@ class GDALTileFactory:
         # Use the request and metadata from the raster dataset to create a set of keyword
         # arguments for the gdal.Translate() function. This will configure that function to
         # create image tiles using the format, compression, etc. requested by the client.
-        gdal_translate_kwargs = self.default_gdal_translate_kwargs.copy()
+        gdal_translate_kwargs = copy.deepcopy(self.default_gdal_translate_kwargs)
 
         if output_size is not None:
             gdal_translate_kwargs["width"] = output_size[0]


### PR DESCRIPTION
This change corrects a problem that caused the GDALTileFactory to write incorrect XML metadata with SICD tiles. Metadata of that kind is provided to the underlying gdal.translate() function through a dictionary of keyword arguments. Some of those arguments remain the same for an entire image while others vary from tile to tile. When multiple tiles were created from the same image some arguments were carried forward to other chips due to a programming error (a shallow vs. deep copy of an argument that was itself a list of values). As a consequence all tiles after the first one may have incorrect metatada encoded that was leftover from previous tiles. 

### Notes
Changes have been verified in an integration test environment and are being released ASAP given the severity of the issue. Follow-on PRs will address the gaps in automated testing. 

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
