### PR TITLE
feat: adding an alpha mask to ortho map tiles for pixels in the tile but outside the image

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,4 +17,4 @@ partial_branches =
 
 show_missing = True
 
-fail_under = 60
+fail_under = 96

--- a/test/data/small.tif
+++ b/test/data/small.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:503276dfbe7ff685f0b7fe212b8abfef1ee7b9dfc2abbcde136aedb16e760740
+size 26111474


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Adding an alpha layer to map tiles to account for cases when the image data does not completely fill the map tile.  Previously these pixels would be filled with black which obstructed the view of lower map layers.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
