### PR TITLE
fix: remove border between map tiles

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,9 @@ envlist =
 # Pre distribution checks for the package
     twine
 
-requires = tox-conda
+requires =
+    setuptools
+    tox-conda
 skip_missing_interpreters = False
 
 [testenv]


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- This quick fix addresses an issue with the border between the map tiles and out-of-bound pixel coordinates during the remapping process using cv2.remap. When performing image remapping, some coordinates may fall outside the boundaries of the source image. By default, this can result in unwanted black borders if cv2.BORDER_CONSTANT is used, as pixels outside the image bounds are filled with a constant color (typically black). To mitigate this, the code uses `copyMakeBorder` and uses `cv2.BORDER_REPLICATE`, which replicates the edge pixels of the source image around the border. This allows `cv2.remap` to use valid pixel values for out-of-bound coordinates, avoiding the default black borders around the output image. This solution ensures that the edges blend naturally, maintaining visual consistency and avoiding artifacts caused by uniform-colored borders. See below (**before**):

![image](https://github.com/user-attachments/assets/870d1aa7-235a-4d3b-9e91-1f87813ad916)

**After:**

<img width="556" alt="Screenshot 2024-09-25 at 2 33 32 PM" src="https://github.com/user-attachments/assets/18368d9d-87d6-4d71-abdc-8071b76345c7">

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
