### PR TITLE
fix: DRA range calculation for imagery with more than 8 BPP

### DIFF
--- a/src/aws/osml/image_processing/gdal_tile_factory.py
+++ b/src/aws/osml/image_processing/gdal_tile_factory.py
@@ -475,8 +475,10 @@ class GDALTileFactory:
         min_value = band.GetMinimum() if band.GetMinimum() is not None else np.min(pixel_array)
         max_value = band.GetMaximum() if band.GetMaximum() is not None else np.max(pixel_array)
 
-        hist = band.GetHistogram(min=min_value, max=max_value, buckets=256)
-        dra_parameters = DRAParameters.from_counts(hist, max_percentage=0.97)
+        hist = band.GetHistogram(min=min_value, max=max_value, buckets=max(256, int(max_value - min_value)))
+        dra_parameters = DRAParameters.from_counts(
+            hist, first_bucket_value=min_value, last_bucket_value=max_value, max_percentage=0.97
+        )
         normalized_pixel = (
             255
             * (pixel_array - dra_parameters.suggested_min_value)

--- a/test/aws/osml/image_processing/test_gdal_tile_factory.py
+++ b/test/aws/osml/image_processing/test_gdal_tile_factory.py
@@ -459,9 +459,11 @@ class TestGDALTileFactory(TestCase):
         pixel_array = np.array([[50, 75, 100], [125, 150, 175]], dtype=np.uint8)
         band = MagicMock(spec=gdal.Band)
         band.GetHistogram.return_value = [0 for i in range(20)] + [10 for i in range(216)] + [0 for i in range(20)]
+        band.GetMinimum.return_value = 20
+        band.GetMaximum.return_value = 216
 
         normalized_pixels = gdal_tile_factory._normalize_band_dra(band, pixel_array)
-        np.testing.assert_array_equal(normalized_pixels, np.array([[35, 65, 94], [124, 154, 183]], dtype=np.uint8))
+        np.testing.assert_array_equal(normalized_pixels, np.array([[22, 61, 100], [138, 177, 216]], dtype=np.uint8))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The dynamic range adjustment (DRA) calculation wasn't correctly handling imagery with more than 8 bits per pixel per band. The original calculation only computed a histogram of 256 bins and it assumed the binned values were 0-255. This update should make the code work with imagery with a larger dynamic range. 

The automated tests were mocked examples and while they exercised the code they didn't catch this problem. They've been updated to validate the current values but a real test was verified using a representative 3-band (RGB) 12 bit per pixel image. (range adjusted 8-bit PNG tile shown below)

![image](https://github.com/user-attachments/assets/a4a8fabf-4cdf-44db-bed5-f773bd6ca572)

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
