### PR TITLE
fix: generic dem tile names for SW hemisphere

### DIFF
--- a/src/aws/osml/photogrammetry/generic_dem_tile_set.py
+++ b/src/aws/osml/photogrammetry/generic_dem_tile_set.py
@@ -1,6 +1,6 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
 
-from math import degrees, floor
+from math import degrees, floor, radians
 from typing import Optional
 
 from .coordinates import GeodeticWorldCoordinate
@@ -22,10 +22,10 @@ class GenericDEMTileSet(DigitalElevationModelTileSet):
     ) -> None:
         """
         Construct a tile set from a limited collection of configurable parameters. This implementation uses the
-        custom formatting directives supplied with GeodeticWorldCoordinate to allow users to create tile IDs
-        that match a variety of situations. For example the default format_spec of '%od%oh/%ld%lh.dt2' will
-        generate tile ids like: '115e/45s.dt2' which would match some common 1-degree cell based DEM file
-        hierarchies.
+        custom formatting directives %od (longitude degrees), %oh (longitude hemisphere), %ld (latitude degrees),
+        and %lh (latitude hemisphere) to allow users to create tile IDs that match a variety of situations.
+        For example the default format_spec of '%od%oh/%ld%lh.dt2' will generate tile ids like: '115e/45s.dt2'
+        which would match some common 1-degree cell based DEM file hierarchies.
 
         :param format_spec: the format specification for the GeodeteticWorldCoordinate
 
@@ -60,4 +60,5 @@ class GenericDEMTileSet(DigitalElevationModelTileSet):
         ):
             return None
 
-        return f"{geodetic_world_coordinate:{self.format_string}}"
+        ul_coordinate = GeodeticWorldCoordinate([radians(longitude_degrees), radians(latitude_degrees), 0.0])
+        return f"{ul_coordinate:{self.format_string}}"

--- a/test/aws/osml/photogrammetry/test_generic_dem_tile_set.py
+++ b/test/aws/osml/photogrammetry/test_generic_dem_tile_set.py
@@ -13,6 +13,14 @@ class TestGenericDEMTileSet(unittest.TestCase):
         tile_path = tile_set.find_tile_id(GeodeticWorldCoordinate([radians(142), radians(3), 0.0]))
         assert "142e/03n.dt2" == tile_path
 
+    def test_sw_hemisphere(self):
+        from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
+        from aws.osml.photogrammetry.generic_dem_tile_set import GenericDEMTileSet
+
+        tile_set = GenericDEMTileSet(format_spec="dted/%oh%od/%lh%ld.dt2")
+        tile_path = tile_set.find_tile_id(GeodeticWorldCoordinate([radians(-43.648601), radians(-22.999056), 42.0]))
+        assert "dted/w044/s23.dt2" == tile_path
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This change fixes an error in how the DEM file names are calculated by the GenericDEMTileSet. The original code did not handle coordinates in the South or West hemispheres correctly (negative decimal degrees values). The DEM tile 044W contains elevation values for coordinates [-44.0, -43.0) so a coordinate value of -43.5 needs to be floored to -44. That is the natural behavior of the python floor() operator but the original implementation was relying on the degrees, minutes, seconds calculation in the GeodeticWorldCoordinate format operator which converts the decimal value to a positive number before truncating the degrees. This change floors the number before passing it into the format string ensuring the correct decimal value is chosen for a DEM tile. Unit tests have been updated to include the failing example that brought this issue to our attention.



### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
