### PR TITLE
docs: correct syntax mistakes in features and external type references

### DIFF
--- a/src/aws/osml/image_processing/__init__.py
+++ b/src/aws/osml/image_processing/__init__.py
@@ -105,14 +105,14 @@ Calibration, and Display (SAND2019-2371).
    :width: 400
    :alt: Histogram Stretch Applied to Sample SICD Image
 
-    Example of applying histogram_stretch to a sample SICD image.
+   Example of applying histogram_stretch to a sample SICD image.
 
 
 .. figure:: ../images/SAR-QuarterPowerImage.png
    :width: 400
    :alt: Quarter Power Image Applied to Sample SICD Image
 
-    Example of applying quarter_power_image to a sample SICD image.
+   Example of applying quarter_power_image to a sample SICD image.
 
 
 -------------------------

--- a/src/aws/osml/photogrammetry/__init__.py
+++ b/src/aws/osml/photogrammetry/__init__.py
@@ -20,7 +20,7 @@ options. These features will be added in a future release.*
    :width: 400
    :alt: Photogrammetry Class Diagram
 
-    Class diagram of the aws.osml.photogrammetry package showing public and private classes.
+   Class diagram of the aws.osml.photogrammetry package showing public and private classes.
 
 Geolocating Image Pixels: Basic Examples
 ****************************************
@@ -77,9 +77,12 @@ available we assume a constant surface with elevation provided in the image meta
     :caption: Example showing use of an external SRTM DEM to provide elevation data for image center
 
     ds, sensor_model = load_gdal_dataset("./imagery/sample.nitf")
+
+    # This sets up an external elevation model assuming terrain data is named something like:
+    # ./SRTM/dted/w044/s23.dt2.
     elevation_model = DigitalElevationModel(
-        SRTMTileSet(version="1arc_v3"),
-        GDALDigitalElevationModelTileFactory("./local-SRTM-tiles"))
+        GenericDEMTileSet(format_spec="format_spec="dted/%oh%od/%lh%ld.dt2"),
+        GDALDigitalElevationModelTileFactory("./SRTM"))
 
     # Note the order of ImageCoordinate is (x, y) and the resulting geodetic coordinate is
     # (longitude, latitude, elevation) with longitude and latitude in **radians** and elevation in meters.

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
 skip_install = true
 conda_env =
 deps = pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
+commands = pre-commit run --all-files
 
 [testenv:twine]
 conda_env =
@@ -51,7 +51,7 @@ commands =
     twine check dist/*.tar.gz
 
 [testenv:docs]
-conda_env =
+conda_env = {toxinidir}/environment.yml
 changedir = doc
 deps =
     sphinx>=6.2.1


### PR DESCRIPTION
These changes correct a few small syntax errors noticed in the Sphinx doc generation process. The captions for several figures were not being generated correctly because of indent levels. This change also makes a small update to the DEM example to encourage use of the GenericDEMTileSet instead of the more restrictive version that only works with the USGS commercial SRTM files.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
