### PR TITLE
build: set numpy version limits

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,8 @@ python_requires = >=3.9
 include_package_data = True
 
 install_requires =
-    numpy>=1.23.0
+    numpy>=1.23.0,<2.0;python_version<'3.12'
+    numpy>=1.23.0,<2.3.0;python_version>='3.12'
     scikit-optimize>=0.9.0
     opencv-python-headless>=4.9.0
     cachetools>=5.3.2


### PR DESCRIPTION
This change sets upper limits on the NumPy versions associated with the osml-imagery-toolkit. These limits are not caused by the toolkit code itself but they are consequences of the dependencies (e.g. GDAL, AWS build environments, etc.) frequently associated with this package. This should be thought of as a temporary limitation we will work to remove or refine in the future.

### Notes
* There are some compatibility issues with NumPy 2.3.0 and the AWS Lambda ecosystem. (e.g. https://github.com/aws/aws-cdk/issues/34685). Pinning this library to <2.3.0 until these issues are resolved.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
