### PR TITLE
fix: undo generic tile set rounding

### DIFF
--- a/src/aws/osml/photogrammetry/coordinates.py
+++ b/src/aws/osml/photogrammetry/coordinates.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
 import numpy as np
 import numpy.typing as npt
@@ -159,7 +160,7 @@ class GeodeticWorldCoordinate(WorldCoordinate):
         if lat_degrees < 0:
             lat_degrees *= -1.0
             lh = "S"
-        ld = int(lat_degrees)
+        ld = int(round(lat_degrees, 6))
         lm = int(round(lat_degrees - ld, 6) * 60)
         ls = int(round(lat_degrees - ld - lm / 60, 6) * 3600)
 
@@ -168,7 +169,7 @@ class GeodeticWorldCoordinate(WorldCoordinate):
         if lon_degrees < 0:
             lon_degrees *= -1.0
             oh = "W"
-        od = int(lon_degrees)
+        od = int(round(lon_degrees, 6))
         om = int(round(lon_degrees - od, 6) * 60)
         os = int(round(lon_degrees - od - om / 60, 6) * 3600)
 

--- a/test/aws/osml/photogrammetry/test_generic_dem_tile_set.py
+++ b/test/aws/osml/photogrammetry/test_generic_dem_tile_set.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from math import radians
@@ -20,6 +21,16 @@ class TestGenericDEMTileSet(unittest.TestCase):
         tile_set = GenericDEMTileSet(format_spec="dted/%oh%od/%lh%ld.dt2")
         tile_path = tile_set.find_tile_id(GeodeticWorldCoordinate([radians(-43.648601), radians(-22.999056), 42.0]))
         assert "dted/w044/s23.dt2" == tile_path
+
+    def test_edge_rounding(self):
+        from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
+        from aws.osml.photogrammetry.generic_dem_tile_set import GenericDEMTileSet
+
+        tile_set = GenericDEMTileSet(format_spec="dted/%oh%od/%lh%ld.dt2")
+        # test intermediate flooring example that fails:
+        # degrees(radians(floor(degrees(radians(30.5))))) = 29.999999999999996
+        tile_path = tile_set.find_tile_id(GeodeticWorldCoordinate([radians(30.5), radians(1.5), 0.0]))
+        assert "dted/e030/n01.dt2" == tile_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `GenericDEMTileSet` was previously updated to floor values prior to formatting in order to handle negative coordinates. With that change, the post-flooring degree/radian conversions can cause casting by formatting to produce the wrong tile path.

`GenericDEMTileSet` uses `floor(degrees(coordinate` before converting to `radians` / world coordinate for formatting. Formatting may convert back to `degrees` then cast to `int`. Any error in the conversion can lead to casting the wrong value. See the additional unit test, which failed previously.

~A new coordinate format has been introduced for floored values to bypass the extra conversion. This change additionally preserves the intended formatting of any format string that doesn't use round.~ Additional rounding has been added to coordinate formatting for longitude / latitude.

### Notes

~:warning: *This update will require users to alter tile set format strings.*~

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
