### PR TITLE
feat: add sensor model options for convergence

### DIFF
--- a/src/aws/osml/photogrammetry/replacement_sensor_model.py
+++ b/src/aws/osml/photogrammetry/replacement_sensor_model.py
@@ -1,5 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
-#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+#  Copyright 2025-2026 General Atomics Integrated Intelligence, Inc.
 
 from abc import ABC
 from enum import Enum
@@ -516,6 +516,8 @@ class RSMPolynomialSensorModel(RSMSensorModel):
                 ],
             )
 
+        options = options if options is not None else {}
+
         # This is the function we will be minimizing. Given a longitude, latitude coordinate we invoke the
         # world_to_image function to get a projection of that location in the image. Then we compute the
         # distance between that new image location and the input image location. When those locations match then
@@ -533,9 +535,10 @@ class RSMPolynomialSensorModel(RSMSensorModel):
         # at the center of the ground domain.
         v1 = self.context.ground_domain.geodetic_ground_domain_vertices[0]
         v4 = self.context.ground_domain.geodetic_ground_domain_vertices[3]
-        initial_guess = options.get(SensorModelOptions.INITIAL_GUESS) if options is not None else None
-        if initial_guess is None:
-            initial_guess = np.array([(v1.longitude + v4.longitude) / 2.0, (v1.latitude + v4.latitude) / 2.0])
+        initial_guess = options.get(
+            SensorModelOptions.INITIAL_GUESS,
+            np.array([(v1.longitude + v4.longitude) / 2.0, (v1.latitude + v4.latitude) / 2.0]),
+        )
         if isinstance(initial_guess, List):
             initial_guess = np.array(initial_guess)
         initial_guess = self.context.ground_domain.ground_domain_coordinate_to_geodetic(
@@ -544,37 +547,51 @@ class RSMPolynomialSensorModel(RSMSensorModel):
             ),
         ).coordinate[:2]
 
-        initial_search_distance = options.get(SensorModelOptions.INITIAL_SEARCH_DISTANCE) if options is not None else None
-        if initial_search_distance is None:
-            initial_search_distance = sqrt(((v1.longitude - v4.longitude) ** 2) + ((v1.latitude - v4.latitude) ** 2))
+        if options.get(SensorModelOptions.FORCE_INITIAL_GUESS, False) is True:
+            world_coordinate = GeodeticWorldCoordinate(np.append(initial_guess, 0.0))
+        else:
+            initial_search_distance = options.get(
+                SensorModelOptions.INITIAL_SEARCH_DISTANCE,
+                sqrt(((v1.longitude - v4.longitude) ** 2) + ((v1.latitude - v4.latitude) ** 2)),
+            )
 
-        # Iteratively adjust the initial guess to minimize the distance to the target image coordinate. We are only
-        # allowing the x,y components to vary here and the z is fixed to the elevation model used by the ground
-        # domain. The starting simplex is estimated as a triangle centered in the ground domain.
-        res = minimize(
-            distance_to_target_coordinate,
-            initial_guess,
-            method="Nelder-Mead",
-            bounds=[
-                (
-                    self.context.ground_domain.geodetic_lonlat_bbox[0],
-                    self.context.ground_domain.geodetic_lonlat_bbox[2],
-                ),
-                (
-                    self.context.ground_domain.geodetic_lonlat_bbox[1],
-                    self.context.ground_domain.geodetic_lonlat_bbox[3],
-                ),
-            ],
-            options={
-                "xatol": radians(0.000001),
-                "fatol": 0.5,
-                "initial_simplex": equilateral_triangle(initial_guess.tolist(), initial_search_distance),
-            },
-        )
+            # Iteratively adjust the initial guess to minimize the distance to the target image coordinate. We are only
+            # allowing the x,y components to vary here and the z is fixed to the elevation model used by the ground
+            # domain. The starting simplex is estimated as a triangle centered in the ground domain.
+            res = minimize(
+                distance_to_target_coordinate,
+                initial_guess,
+                method="Nelder-Mead",
+                bounds=[
+                    (
+                        self.context.ground_domain.geodetic_lonlat_bbox[0],
+                        self.context.ground_domain.geodetic_lonlat_bbox[2],
+                    ),
+                    (
+                        self.context.ground_domain.geodetic_lonlat_bbox[1],
+                        self.context.ground_domain.geodetic_lonlat_bbox[3],
+                    ),
+                ],
+                options={
+                    "xatol": radians(0.000001),
+                    "fatol": 0.5,
+                    "initial_simplex": equilateral_triangle(initial_guess.tolist(), initial_search_distance),
+                },
+            )
+
+            # The minimization result is a (longitude,latitude) tuple, so we need to expand it to
+            # longitude,latitude,elevation and replace the z component with the height from the elevation model.
+            world_coordinate = GeodeticWorldCoordinate(np.append(res.x, 0.0))
+            success = res.success
+            min_dist = options.get(SensorModelOptions.MIN_SUCCESS_DISTANCE_PIXELS, 1.0)
+            if not success or distance_to_target_coordinate(world_coordinate.coordinate[:2]) > min_dist:
+                if options.get(SensorModelOptions.FALLBACK_INITIAL_GUESS, False) is True:
+                    world_coordinate = GeodeticWorldCoordinate(np.append(initial_guess, 0.0))
+                elif options.get(SensorModelOptions.EXCEPTION_ON_FAILURE, False) is True:
+                    raise RuntimeError(f"{self.__class__.__name__} failed to converge.")
 
         # The minimization result is a (longitude,latitude) tuple, so we need to expand it to
         # longitude,latitude,elevation and replace the z component with the height from the elevation model.
-        world_coordinate = GeodeticWorldCoordinate(np.append(res.x, 0.0))
         elevation_model.set_elevation(world_coordinate)
 
         return world_coordinate.normalized()

--- a/src/aws/osml/photogrammetry/rpc_sensor_model.py
+++ b/src/aws/osml/photogrammetry/rpc_sensor_model.py
@@ -1,5 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
-#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+#  Copyright 2025-2026 General Atomics Integrated Intelligence, Inc.
 
 from math import degrees, radians, sqrt
 from typing import Any, Dict, List, Optional, Tuple
@@ -212,6 +212,8 @@ class RPCSensorModel(SensorModel):
                 ],
             )
 
+        options = options if options is not None else {}
+
         # This is the function we will be minimizing. Given an x,y coordinate in the ground domain we use invoke the
         # ground_domain_to_image function to get a projection of that location in the image. Then we compute the
         # distance between that new image location and the input image location. When those locations match then
@@ -226,33 +228,45 @@ class RPCSensorModel(SensorModel):
 
         # Select an initial guess using the normalization offsets for this camera model. Normally these are values
         # near an image corner or the center
-        initial_guess = options.get(SensorModelOptions.INITIAL_GUESS) if options is not None else None
-        if initial_guess is None:
-            initial_guess = np.array([radians(self.long_off), radians(self.lat_off)])
+        initial_guess = options.get(
+            SensorModelOptions.INITIAL_GUESS,
+            np.array([radians(self.long_off), radians(self.lat_off)]),
+        )
         if isinstance(initial_guess, List):
             initial_guess = np.array(initial_guess)
 
-        initial_search_distance = options.get(SensorModelOptions.INITIAL_SEARCH_DISTANCE) if options is not None else None
-        if initial_search_distance is None:
-            initial_search_distance = radians(0.5)
+        if options.get(SensorModelOptions.FORCE_INITIAL_GUESS, False) is True:
+            world_coordinate = GeodeticWorldCoordinate(np.append(initial_guess, 0.0))
+        else:
+            initial_search_distance = options.get(SensorModelOptions.INITIAL_SEARCH_DISTANCE, radians(0.5))
 
-        # Iteratively adjust the initial guess to minimize the distance to the target image coordinate. We are only
-        # allowing the x,y components to vary here and the z is fixed to the elevation model. The starting simplex
-        # is estimated as a triangle centered on the normalization offsets for this RPC.
-        res = minimize(
-            distance_to_target_coordinate,
-            initial_guess,
-            method="Nelder-Mead",
-            options={
-                "xatol": radians(0.000001),
-                "fatol": 0.5,
-                "initial_simplex": equilateral_triangle(initial_guess.tolist(), initial_search_distance),
-            },
-        )
+            # Iteratively adjust the initial guess to minimize the distance to the target image coordinate. We are only
+            # allowing the x,y components to vary here and the z is fixed to the elevation model. The starting simplex
+            # is estimated as a triangle centered on the normalization offsets for this RPC.
+            res = minimize(
+                distance_to_target_coordinate,
+                initial_guess,
+                method="Nelder-Mead",
+                options={
+                    "xatol": radians(0.000001),
+                    "fatol": 0.5,
+                    "initial_simplex": equilateral_triangle(initial_guess.tolist(), initial_search_distance),
+                },
+            )
+
+            # The minimization result is an (x,y) tuple, so we need to expand it to x,y,z and replace the z component with
+            # the height from the elevation model. Note that the units of this are radians, radians, meters
+            world_coordinate = GeodeticWorldCoordinate(np.append(res.x, 0.0))
+            success = res.success
+            min_dist = options.get(SensorModelOptions.MIN_SUCCESS_DISTANCE_PIXELS, 1.0)
+            if not success or distance_to_target_coordinate(world_coordinate.coordinate[:2]) > min_dist:
+                if options.get(SensorModelOptions.FALLBACK_INITIAL_GUESS, False) is True:
+                    world_coordinate = GeodeticWorldCoordinate(np.append(initial_guess, 0.0))
+                elif options.get(SensorModelOptions.EXCEPTION_ON_FAILURE, False) is True:
+                    raise RuntimeError(f"{self.__class__.__name__} failed to converge.")
 
         # The minimization result is an (x,y) tuple, so we need to expand it to x,y,z and replace the z component with
         # the height from the elevation model. Note that the units of this are radians, radians, meters
-        world_coordinate = GeodeticWorldCoordinate(np.append(res.x, 0.0))
         elevation_model.set_elevation(world_coordinate)
 
         return world_coordinate

--- a/src/aws/osml/photogrammetry/sensor_model.py
+++ b/src/aws/osml/photogrammetry/sensor_model.py
@@ -1,5 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
-#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+#  Copyright 2025-2026 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from abc import ABC, abstractmethod
@@ -59,6 +59,10 @@ class SensorModelOptions(str, Enum):
     included here to encourage convention.
     """
 
+    EXCEPTION_ON_FAILURE = "exception_on_failure"
+    FALLBACK_INITIAL_GUESS = "fallback_initial_guess"
+    FORCE_INITIAL_GUESS = "force_initial_guess"
+    IGNORE_DEFAULT_ELEVATION_MODEL = "ignore_default_elevation_model"
     INITIAL_GUESS = "initial_guess"
     INITIAL_SEARCH_DISTANCE = "initial_search_distance"
-    IGNORE_DEFAULT_ELEVATION_MODEL = "ignore_default_elevation_model"
+    MIN_SUCCESS_DISTANCE_PIXELS = "min_success_distance_pixels"

--- a/test/aws/osml/photogrammetry/test_replacement_sensor_model.py
+++ b/test/aws/osml/photogrammetry/test_replacement_sensor_model.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from math import radians
@@ -130,6 +131,45 @@ class TestMathUtils(unittest.TestCase):
         )
 
         assert np.allclose(world_coordinate.coordinate, new_world_coordinate.coordinate)
+
+    def test_polynomial_sensor_model_options(self):
+        from aws.osml.photogrammetry.coordinates import ImageCoordinate
+        from aws.osml.photogrammetry.sensor_model import SensorModelOptions
+
+        image_coordinate = ImageCoordinate([100.0 * radians(5.0), 100.0 * radians(5.0)])
+        initial_guess = [radians(5.1), radians(5.1)]
+
+        # Test forcing the initial guess.
+        new_world_coordinate = self.sample_polynomial_sensor_model.image_to_world(
+            image_coordinate,
+            options={
+                SensorModelOptions.INITIAL_GUESS: initial_guess,
+                SensorModelOptions.FORCE_INITIAL_GUESS: True,
+            },
+        )
+        assert np.allclose(initial_guess, new_world_coordinate.coordinate[:2])
+
+        # Test convergence failure.
+        with pytest.raises(RuntimeError):
+            new_world_coordinate = self.sample_polynomial_sensor_model.image_to_world(
+                image_coordinate,
+                options={
+                    SensorModelOptions.INITIAL_GUESS: initial_guess,
+                    SensorModelOptions.MIN_SUCCESS_DISTANCE_PIXELS: 0.0,
+                    SensorModelOptions.EXCEPTION_ON_FAILURE: True,
+                },
+            )
+
+        # Test convergence fallback.
+        new_world_coordinate = self.sample_polynomial_sensor_model.image_to_world(
+            image_coordinate,
+            options={
+                SensorModelOptions.INITIAL_GUESS: initial_guess,
+                SensorModelOptions.MIN_SUCCESS_DISTANCE_PIXELS: 0.0,
+                SensorModelOptions.FALLBACK_INITIAL_GUESS: True,
+            },
+        )
+        assert np.allclose(initial_guess, new_world_coordinate.coordinate[:2])
 
     def test_segmented_polynomial_sensor_model(self):
         from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate

--- a/test/aws/osml/photogrammetry/test_rpc_sensor_model.py
+++ b/test/aws/osml/photogrammetry/test_rpc_sensor_model.py
@@ -1,9 +1,11 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from math import radians
 
 import numpy as np
+import pytest
 
 
 class TestRPCSensorModel(unittest.TestCase):
@@ -66,6 +68,50 @@ class TestRPCSensorModel(unittest.TestCase):
         )
 
         assert np.allclose(world_coordinate.coordinate, new_world_coordinate.coordinate)
+
+    def test_rpc_sensor_model_options(self):
+        from aws.osml.photogrammetry.coordinates import ImageCoordinate
+        from aws.osml.photogrammetry.elevation_model import ConstantElevationModel
+        from aws.osml.photogrammetry.sensor_model import SensorModelOptions
+
+        elevation_model = ConstantElevationModel(42.0)
+        image_coordinate = ImageCoordinate((5.0, 3.0))
+        initial_guess = [radians(5.1), radians(3.1)]
+
+        # Test forcing the initial guess.
+        new_world_coordinate = self.sample_rpc_sensor_model.image_to_world(
+            image_coordinate,
+            elevation_model=elevation_model,
+            options={
+                SensorModelOptions.INITIAL_GUESS: initial_guess,
+                SensorModelOptions.FORCE_INITIAL_GUESS: True,
+            },
+        )
+        assert np.allclose(initial_guess, new_world_coordinate.coordinate[:2])
+
+        # Test convergence failure.
+        with pytest.raises(RuntimeError):
+            new_world_coordinate = self.sample_rpc_sensor_model.image_to_world(
+                image_coordinate,
+                elevation_model=elevation_model,
+                options={
+                    SensorModelOptions.INITIAL_GUESS: initial_guess,
+                    SensorModelOptions.MIN_SUCCESS_DISTANCE_PIXELS: 0.0,
+                    SensorModelOptions.EXCEPTION_ON_FAILURE: True,
+                },
+            )
+
+        # Test convergence fallback.
+        new_world_coordinate = self.sample_rpc_sensor_model.image_to_world(
+            image_coordinate,
+            elevation_model=elevation_model,
+            options={
+                SensorModelOptions.INITIAL_GUESS: initial_guess,
+                SensorModelOptions.MIN_SUCCESS_DISTANCE_PIXELS: 0.0,
+                SensorModelOptions.FALLBACK_INITIAL_GUESS: True,
+            },
+        )
+        assert np.allclose(initial_guess, new_world_coordinate.coordinate[:2])
 
     def test_rpc_sensor_model_realworld(self):
         from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate


### PR DESCRIPTION
Four new sensor model options have been added with usage in RPC / RSM sensor models. These are:
  - `EXCEPTION_ON_FAILURE` -> don't return the failed result, raise `RuntimeError` instead
  - `FALLBACK_INITIAL_GUESS` -> on failure, return the initial guess instead of the failed result
  - `FORCE_INITIAL_GUESS` -> always return the initial guess from whatever lowest model _could_ fail
  - `MIN_SUCCESS_DISTANCE_PIXELS` -> distance threshold check for success to combine with convergence check

### Notes

~Testing TBD.~

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
