### PR TITLE
fix: remove search distance update from composite model

### DIFF
--- a/src/aws/osml/photogrammetry/composite_sensor_model.py
+++ b/src/aws/osml/photogrammetry/composite_sensor_model.py
@@ -1,6 +1,6 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
-import math
 from typing import Any, Dict, Optional
 
 from .coordinates import GeodeticWorldCoordinate, ImageCoordinate
@@ -52,7 +52,6 @@ class CompositeSensorModel(SensorModel):
             approximate_coord.longitude,
             approximate_coord.latitude,
         ]
-        updated_options[SensorModelOptions.INITIAL_SEARCH_DISTANCE] = math.radians(0.005)
         return self.precision_sensor_model.image_to_world(
             image_coordinate, elevation_model=elevation_model, options=updated_options
         )


### PR DESCRIPTION
Undo the search distance override in the `CompositeSensorModel`. This value may be too small and there is no way to change it.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
