### PR TITLE
fix: limit xsdata using contexts

### DIFF
--- a/src/aws/osml/formats/model_utils.py
+++ b/src/aws/osml/formats/model_utils.py
@@ -1,0 +1,15 @@
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
+
+from xsdata.formats.dataclass.context import XmlContext
+from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.serializers import XmlSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
+
+serializer_config = SerializerConfig(pretty_print=False)
+
+sicd_context = XmlContext(models_package=("aws.osml.formats.sicd.models"))
+sicd_parser = XmlParser(context=sicd_context)
+sicd_serializer = XmlSerializer(context=sicd_context, config=serializer_config)
+sidd_context = XmlContext(models_package=("aws.osml.formats.sidd.models"))
+sidd_parser = XmlParser(context=sidd_context)
+sidd_serializer = XmlSerializer(context=sidd_context, config=serializer_config)

--- a/src/aws/osml/gdal/sicd_sensor_model_builder.py
+++ b/src/aws/osml/gdal/sicd_sensor_model_builder.py
@@ -1,13 +1,14 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from typing import Optional, Union
 
 import numpy as np
-from xsdata.formats.dataclass.parsers import XmlParser
 
 import aws.osml.formats.sicd.models.sicd_v1_2_1 as sicd121
 import aws.osml.formats.sicd.models.sicd_v1_3_0 as sicd130
+from aws.osml.formats.model_utils import sicd_parser
 
 from ..photogrammetry import (
     ImageCoordinate,
@@ -105,8 +106,7 @@ class SICDSensorModelBuilder(SensorModelBuilder):
             if self.sicd_xml is None or len(self.sicd_xml) == 0:
                 return None
 
-            parser = XmlParser()
-            sicd = parser.from_string(self.sicd_xml)
+            sicd = sicd_parser.from_string(self.sicd_xml)
             return SICDSensorModelBuilder.from_dataclass(sicd)
         except Exception as e:
             logging.error("Exception caught attempting to build SICD sensor model.", e)

--- a/src/aws/osml/gdal/sidd_sensor_model_builder.py
+++ b/src/aws/osml/gdal/sidd_sensor_model_builder.py
@@ -1,14 +1,13 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
-#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+#  Copyright 2025-2026 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from typing import Optional, Union
 
-from xsdata.formats.dataclass.parsers import XmlParser
-
 import aws.osml.formats.sidd.models.sidd_v1_0_0 as sidd100
 import aws.osml.formats.sidd.models.sidd_v2_0_0 as sidd200
 import aws.osml.formats.sidd.models.sidd_v3_0_0 as sidd300
+from aws.osml.formats.model_utils import sidd_parser
 
 from ..photogrammetry import (
     ChippedImageSensorModel,
@@ -54,8 +53,7 @@ class SIDDSensorModelBuilder(SensorModelBuilder):
             if self.sidd_xml is None or len(self.sidd_xml) == 0:
                 return None
 
-            parser = XmlParser()
-            sicd = parser.from_string(self.sidd_xml)
+            sicd = sidd_parser.from_string(self.sidd_xml)
             return SIDDSensorModelBuilder.from_dataclass(sicd)
         except Exception as e:
             logging.error("Exception caught attempting to build SIDD sensor model.", e)

--- a/src/aws/osml/image_processing/sicd_updater.py
+++ b/src/aws/osml/image_processing/sicd_updater.py
@@ -1,12 +1,11 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from math import floor
 from typing import List, Optional, Tuple
 
-from xsdata.formats.dataclass.parsers import XmlParser
-from xsdata.formats.dataclass.serializers import XmlSerializer
-from xsdata.formats.dataclass.serializers.config import SerializerConfig
+from aws.osml.formats.model_utils import sicd_parser, sicd_serializer
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +23,7 @@ class SICDUpdater:
         """
         self.xml_str = xml_str
         if self.xml_str is not None and len(self.xml_str) > 0:
-            parser = XmlParser()
-            self.sicd = parser.from_string(self.xml_str)
+            self.sicd = sicd_parser.from_string(self.xml_str)
 
         # Here we're storing off the original first row/col to support the case where multiple chips are
         # created from a SICD image that has already been chipped.
@@ -67,6 +65,5 @@ class SICDUpdater:
 
         :return: xml encoded SICD metadata
         """
-        serializer = XmlSerializer(config=SerializerConfig(pretty_print=False))
-        updated_xml = serializer.render(self.sicd)
+        updated_xml = sicd_serializer.render(self.sicd)
         return updated_xml

--- a/src/aws/osml/image_processing/sidd_updater.py
+++ b/src/aws/osml/image_processing/sidd_updater.py
@@ -1,15 +1,13 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from typing import List, Optional, Tuple
 
-from xsdata.formats.dataclass.parsers import XmlParser
-from xsdata.formats.dataclass.serializers import XmlSerializer
-from xsdata.formats.dataclass.serializers.config import SerializerConfig
-
 import aws.osml.formats.sidd.models.sidd_v1_0_0 as sidd100
 import aws.osml.formats.sidd.models.sidd_v2_0_0 as sidd200
 import aws.osml.formats.sidd.models.sidd_v3_0_0 as sidd300
+from aws.osml.formats.model_utils import sidd_parser, sidd_serializer
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +21,7 @@ class SIDDUpdater:
         """
         self.xml_str = xml_str
         if self.xml_str is not None and len(self.xml_str) > 0:
-            parser = XmlParser()
-            self.sidd = parser.from_string(self.xml_str)
+            self.sidd = sidd_parser.from_string(self.xml_str)
 
     def update_image_data_for_chip(self, chip_bounds: List[int], output_size: Optional[Tuple[int, int]]) -> None:
         """
@@ -140,8 +137,7 @@ class SIDDUpdater:
 
         :return: xml encoded SIDD metadata
         """
-        serializer = XmlSerializer(config=SerializerConfig(pretty_print=False))
-        updated_xml = serializer.render(self.sidd)
+        updated_xml = sidd_serializer.render(self.sidd)
         return updated_xml
 
     @staticmethod

--- a/test/aws/osml/formats/test_sidd_schemas.py
+++ b/test/aws/osml/formats/test_sidd_schemas.py
@@ -1,15 +1,15 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2026-2026 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from pathlib import Path
 
-from xsdata.formats.dataclass.parsers import XmlParser
-
 import aws.osml.formats.sidd.models.sidd_v2_0_0 as sidd2
+from aws.osml.formats.model_utils import sidd_parser
 
 
 class TestSIDDFormats(unittest.TestCase):
     def test_sidd_20(self):
-        sidd = XmlParser().from_path(Path("./test/data/sidd/example.sidd.xml"))
+        sidd = sidd_parser.from_path(Path("./test/data/sidd/example.sidd.xml"))
 
         assert isinstance(sidd, sidd2.SIDD)

--- a/test/aws/osml/photogrammetry/test_sicd_sensor_model.py
+++ b/test/aws/osml/photogrammetry/test_sicd_sensor_model.py
@@ -1,5 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
-#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+#  Copyright 2025-2026 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from math import radians
@@ -7,9 +7,9 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import numpy as np
-from xsdata.formats.dataclass.parsers import XmlParser
 
 import aws.osml.formats.sicd.models.sicd_v1_2_1 as sicd121
+from aws.osml.formats.model_utils import sicd_parser
 from aws.osml.gdal.sicd_sensor_model_builder import poly1d_to_native, poly2d_to_native, xyzpoly_to_native, xyztype_to_ndarray
 from aws.osml.photogrammetry import (
     ConstantElevationModel,
@@ -35,7 +35,7 @@ class TestSICDSensorModel(unittest.TestCase):
         pass
 
     def test_xrgycr(self):
-        sicd: sicd121.SICD = XmlParser().from_path(Path("./test/data/sicd/example.sicd121.rma.xml"))
+        sicd: sicd121.SICD = sicd_parser.from_path(Path("./test/data/sicd/example.sicd121.rma.xml"))
 
         scp_ecf = WorldCoordinate(xyztype_to_ndarray(sicd.geo_data.scp.ecf))
         scp_pixel = ImageCoordinate([sicd.image_data.scppixel.col, sicd.image_data.scppixel.row])
@@ -129,7 +129,7 @@ class TestSICDSensorModel(unittest.TestCase):
         assert np.allclose(calculated_image_scp.coordinate, scp_pixel.coordinate)
 
     def test_rgzero_inca(self):
-        sicd: sicd121.SICD = XmlParser().from_path(Path("./test/data/sicd/example.sicd121.capella.xml"))
+        sicd: sicd121.SICD = sicd_parser.from_path(Path("./test/data/sicd/example.sicd121.capella.xml"))
 
         scp_ecf = WorldCoordinate(xyztype_to_ndarray(sicd.geo_data.scp.ecf))
         scp_pixel = ImageCoordinate([sicd.image_data.scppixel.col, sicd.image_data.scppixel.row])
@@ -214,7 +214,7 @@ class TestSICDSensorModel(unittest.TestCase):
             assert np.allclose(new_geo_point.coordinate[0:2], geo_point.coordinate[0:2], atol=0.00001)
 
     def test_rgazim_pfa(self):
-        sicd: sicd121.SICD = XmlParser().from_path(Path("./test/data/sicd/example.sicd121.pfa.xml"))
+        sicd: sicd121.SICD = sicd_parser.from_path(Path("./test/data/sicd/example.sicd121.pfa.xml"))
 
         scp_ecf = WorldCoordinate(xyztype_to_ndarray(sicd.geo_data.scp.ecf))
         scp_pixel = ImageCoordinate([sicd.image_data.scppixel.col, sicd.image_data.scppixel.row])

--- a/test/aws/osml/photogrammetry/test_sidd_sensor_model.py
+++ b/test/aws/osml/photogrammetry/test_sidd_sensor_model.py
@@ -1,14 +1,14 @@
 #  Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
-#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+#  Copyright 2025-2026 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from math import radians
 from pathlib import Path
 
 import numpy as np
-from xsdata.formats.dataclass.parsers import XmlParser
 
 import aws.osml.formats.sidd.models.sidd_v2_0_0 as sidd200
+from aws.osml.formats.model_utils import sidd_parser
 from aws.osml.gdal.sidd_sensor_model_builder import SIDDSensorModelBuilder
 from aws.osml.photogrammetry import (
     ChippedImageSensorModel,
@@ -21,7 +21,7 @@ from aws.osml.photogrammetry import (
 
 class TestSIDDSensorModel(unittest.TestCase):
     def test_planar_projection(self):
-        sidd: sidd200.SIDD = XmlParser().from_path(Path("./test/data/sidd/example.sidd.xml"))
+        sidd: sidd200.SIDD = sidd_parser.from_path(Path("./test/data/sidd/example.sidd.xml"))
 
         sm = SIDDSensorModelBuilder.from_dataclass(sidd)
 
@@ -61,7 +61,7 @@ class TestSIDDSensorModel(unittest.TestCase):
             assert np.allclose(computed_image_location.coordinate, image_location.coordinate, atol=0.5)
 
     def test_chipped_sidd(self):
-        sidd: sidd200.SIDD = XmlParser().from_path(Path("./test/data/sidd/example.sidd-chip.xml"))
+        sidd: sidd200.SIDD = sidd_parser.from_path(Path("./test/data/sidd/example.sidd-chip.xml"))
 
         sm = SIDDSensorModelBuilder.from_dataclass(sidd)
         assert sm is not None


### PR DESCRIPTION
The `XmlParser` from the `xsdata` library will search for available dataclasses to match to incoming data when parsing XML. Dataclasses outside of the `osml-imagery-toolkit` can cause exceptions within `xsdata` (or collide with definitions, though that is less likely) that propagate to the toolkit. XML parsing is used for SICD/SIDD data, and this issue was found through an exception caused by importing `torchvision` prior to loading a SAR dataset with the toolkit's `load_gdal_dataset`.

This exact exception can be replicated including a line like:

```python
FAKE = make_dataclass("TMP", fields=[], module="")
```

prior to loading SAR data. The `build_xsi_cache` function in `xsdata.formats.dataclass.context` will error due to missing `__module__` member of the discovered dataclass. A possible but less likely error could also stem from something like:

```python
__NAMESPACE__ = "urn:SIDD:2.0.0"
@dataclass
class SIDD:
  pass
```

where a bad duplicate could be matched to the data.

Setting an `XmlContext` to limit the dataclasses found prevents these issues. Reusable parsers / serializers have been added to `model_utils` under `formats` to avoid specifying the context at every call.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
