### PR TITLE
build: fix missing pip and add py314

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OversightML Imagery Toolkit
 ![Build Badge](https://github.com/awslabs/osml-imagery-toolkit/actions/workflows/build.yml/badge.svg)
-![Python Badge](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12%2C%203.13-blue)
+![Python Badge](https://img.shields.io/badge/python-3.10%2C%203.11%2C%203.12%2C%203.13%2C%203.14-blue)
 ![GDAL Badge](https://img.shields.io/badge/gdal-3.7%2C%203.8%2C%203.9-blue)
 ![GitHub License](https://img.shields.io/github/license/awslabs/osml-imagery-toolkit?color=blue)
 ![PyPI - Version](https://img.shields.io/pypi/v/osml-imagery-toolkit)

--- a/environment-py310.yml
+++ b/environment-py310.yml
@@ -4,5 +4,6 @@ name: osml_imagery_toolkit
 channels:
   - conda-forge
 dependencies:
+  - conda-forge::pip
   - conda-forge::gdal=3.8.3
   - conda-forge::proj=9.3.1

--- a/environment-py311.yml
+++ b/environment-py311.yml
@@ -4,5 +4,6 @@ name: osml_imagery_toolkit
 channels:
   - conda-forge
 dependencies:
+  - conda-forge::pip
   - conda-forge::gdal=3.8.3
   - conda-forge::proj=9.3.1

--- a/environment-py312.yml
+++ b/environment-py312.yml
@@ -4,5 +4,6 @@ name: osml_imagery_toolkit
 channels:
   - conda-forge
 dependencies:
+  - conda-forge::pip
   - conda-forge::gdal=3.8.5
   - conda-forge::proj=9.4.1

--- a/environment-py314.yml
+++ b/environment-py314.yml
@@ -5,5 +5,5 @@ channels:
   - conda-forge
 dependencies:
   - conda-forge::pip
-  - conda-forge::gdal=3.12.0
-  - conda-forge::proj=9.7.0
+  - conda-forge::gdal=3.13.1
+  - conda-forge::proj=9.8.1

--- a/environment-py39.yml
+++ b/environment-py39.yml
@@ -4,5 +4,6 @@ name: osml_imagery_toolkit
 channels:
   - conda-forge
 dependencies:
+  - conda-forge::pip
   - conda-forge::gdal=3.7.0
   - conda-forge::proj=9.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,6 @@ name: osml_imagery_toolkit
 channels:
   - conda-forge
 dependencies:
+  - conda-forge::pip
   - conda-forge::gdal>=3.7.0,<3.10
   - conda-forge::proj>=9.2.1,<9.6

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 [tox]
 envlist =
 # Basic configurations: Run the tests for each python version.
-    py{39, 310, 311, 312, 313}
+    py{310, 311, 312, 313, 314}
 
 # Build and test the docs with sphinx.
     docs
@@ -26,10 +26,10 @@ allowlist_externals =
     conda
 conda_env = {toxinidir}/environment-{envname}.yml
 deps =
-    pytest==7.2.1
-    pytest-cov==4.0.0
-    pytest-xdist==3.2.0
-    pytest-asyncio==0.20.3
+    pytest>=8.0
+    pytest-cov>=5.0
+    pytest-xdist>=3.5
+    pytest-asyncio>=0.23
     mock==5.0.1
 commands =
     conda list "^(gdal|proj|python)$"


### PR DESCRIPTION
This PR adds the missing pip dependency to conda environments used for builds and adds a new test environment for Python 3.14.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
