### PR TITLE
fix: tox-conda setup failure in docs-all workflow

### DIFF
--- a/.github/workflows/docs-all.yml
+++ b/.github/workflows/docs-all.yml
@@ -33,24 +33,16 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Set up conda (v1 docs)
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          environment-file: v1-src/environment.yml
-          activate-environment: osml_imagery_toolkit
-          auto-activate-base: false
-
       - name: Build v1 docs
-        shell: bash -el {0}
         working-directory: v1-src
         run: |
-          pip install tox tox-conda
+          python -m pip install --upgrade pip tox
           tox -e docs
 
       - name: Build v2 docs
         working-directory: v2-src
         run: |
-          pip install hatch
+          python -m pip install hatch
           hatch run docs:build
 
       - name: Assemble combined site


### PR DESCRIPTION
The docs-all workflow is currently failed in the v1 docs build. Updated the build to setup and run tox the same way the passing unit tests are.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
